### PR TITLE
fix: normalizar 9º dígito em números BR antes do envio

### DIFF
--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -5,6 +5,7 @@ import (
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
 
@@ -83,4 +84,34 @@ func (s *Whatsmiau) NumberExists(ctx context.Context, data *NumberExistsRequest)
 	}
 
 	return results, nil
+}
+
+func (s *Whatsmiau) resolveJID(ctx context.Context, client *whatsmeow.Client, jid types.JID) types.JID {
+	if jid.Server != types.DefaultUserServer {
+		return jid
+	}
+
+	alternate := buildBrazilianAlternate(jid.User)
+	if alternate == "" {
+		return jid
+	}
+
+	resp, err := client.IsOnWhatsApp(ctx, []string{jid.User, alternate})
+	if err != nil {
+		zap.L().Warn("resolveJID: failed to check number on WhatsApp", zap.String("number", jid.User), zap.Error(err))
+		return jid
+	}
+
+	for _, item := range resp {
+		if item.IsIn {
+			resolved := jid
+			resolved.User = item.JID.User
+			if resolved.User != jid.User {
+				zap.L().Debug("resolveJID: brazilian number resolved", zap.String("from", jid.User), zap.String("to", resolved.User))
+			}
+			return resolved
+		}
+	}
+
+	return jid
 }

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -367,3 +367,22 @@ func configProxy(client *whatsmeow.Client, instanceProxy models.InstanceProxy) {
 func mountProxyUrl(proxy models.InstanceProxy) string {
 	return fmt.Sprintf("%s://%s:%s@%s:%s", proxy.ProxyProtocol, proxy.ProxyUsername, proxy.ProxyPassword, proxy.ProxyHost, proxy.ProxyPort)
 }
+
+// Adding or removing the 9th digit. Returns empty if not applicable.
+func buildBrazilianAlternate(number string) string {
+	if !strings.HasPrefix(number, "55") || len(number) < 12 || len(number) > 13 {
+		return ""
+	}
+
+	ddd := number[2:4]
+	local := number[4:]
+
+	switch {
+	case len(local) == 9 && local[0] == '9':
+		return "55" + ddd + local[1:]
+	case len(local) == 8:
+		return "55" + ddd + "9" + local
+	default:
+		return ""
+	}
+}

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -32,6 +32,9 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 		return nil, whatsmeow.ErrClientIsNil
 	}
 
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
 	//rJid := data.RemoteJID.ToNonAD().String()
 	var extendedMessage *waE2E.ExtendedTextMessage
 	if len(data.QuoteMessage) > 0 && len(data.QuoteMessageID) > 0 {
@@ -121,6 +124,9 @@ func (s *Whatsmiau) SendAudio(ctx context.Context, data *SendAudioRequest) (*Sen
 		Waveform:      waveForm,
 	}
 
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
 	res, err := client.SendMessage(ctx, *data.RemoteJID, &waE2E.Message{
 		AudioMessage: &audio,
 	})
@@ -180,6 +186,9 @@ func (s *Whatsmiau) SendDocument(ctx context.Context, data *SendDocumentRequest)
 		DirectPath:    proto.String(uploaded.DirectPath),
 		Caption:       proto.String(data.Caption),
 	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
 
 	res, err := client.SendMessage(ctx, *data.RemoteJID, &waE2E.Message{
 		DocumentMessage: &doc,
@@ -242,6 +251,9 @@ func (s *Whatsmiau) SendImage(ctx context.Context, data *SendImageRequest) (*Sen
 		DirectPath:    proto.String(uploaded.DirectPath),
 	}
 
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
 	res, err := client.SendMessage(ctx, *data.RemoteJID, &waE2E.Message{
 		ImageMessage: &doc,
 	})
@@ -285,6 +297,9 @@ func (s *Whatsmiau) SendReaction(ctx context.Context, data *SendReactionRequest)
 	if client.Store == nil || client.Store.ID == nil {
 		return nil, fmt.Errorf("device is not connected")
 	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
 
 	sender := data.RemoteJID
 	if data.FromMe {

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -32,6 +32,10 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 		return nil, whatsmeow.ErrClientIsNil
 	}
 
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
 	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
 	data.RemoteJID = &resolved
 
@@ -89,6 +93,10 @@ func (s *Whatsmiau) SendAudio(ctx context.Context, data *SendAudioRequest) (*Sen
 	client, ok := s.clients.Load(data.InstanceID)
 	if !ok {
 		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
 	}
 
 	resAudio, err := s.getCtx(ctx, data.AudioURL)
@@ -160,6 +168,10 @@ func (s *Whatsmiau) SendDocument(ctx context.Context, data *SendDocumentRequest)
 		return nil, whatsmeow.ErrClientIsNil
 	}
 
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
 	resMedia, err := s.getCtx(ctx, data.MediaURL)
 	if err != nil {
 		return nil, err
@@ -219,6 +231,10 @@ func (s *Whatsmiau) SendImage(ctx context.Context, data *SendImageRequest) (*Sen
 	client, ok := s.clients.Load(data.InstanceID)
 	if !ok {
 		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
 	}
 
 	resMedia, err := s.getCtx(ctx, data.MediaURL)
@@ -284,6 +300,10 @@ func (s *Whatsmiau) SendReaction(ctx context.Context, data *SendReactionRequest)
 	client, ok := s.clients.Load(data.InstanceID)
 	if !ok {
 		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
 	}
 
 	if len(data.Reaction) <= 0 {


### PR DESCRIPTION
## Problema

Números de telefone no Brasil passaram pela migração do 9º dígito, porém alguns números já estava registrados no WhatsApp antes dessa mudança, mas é comum os usuários se cadastrarem com o 9 antes do número, por habito ou porque as máscaras de telefone dos sistema atuais geralmente exigem ou formatam sempre com 9. 

Dessa forma, percebi que alguns casos (incluindo o meu número) não recebiam a mensagem enviado e a API retornava sucesso.


 ## Solução                                                                                                                                                                                                            

Antes de cada envio, o sistema agora verifica qual variante do número (com ou sem o 9º dígito) está registrada no WhatsApp usando `IsOnWhatsApp`.

- **`buildBrazilianAlternate`** em `helper.go` — gera a variante alternativa do número: se tem 9 dígitos locais e começa com `9`, remove; se tem 8, adiciona.
- **`resolveJID`** em `chat.go` — consulta o WhatsApp com as duas variantes e retorna o JID que está de fato registrado.
- **`O resolveJID`*  é chamado antes do envio em `SendText`, `SendAudio`, `SendDocument`, `SendImage` e `SendReaction`.

Se o número não for brasileiro ou a consulta falhar, o número original é mantido sem alteração.

