### PR TITLE
feat: add sendList, sendButtons and sendPixPayment endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1187,6 +1187,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/instance/{instance}/message/buttons": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive buttons message (reply type) or PIX payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a buttons message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Buttons message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/document": {
             "post": {
                 "security": [
@@ -1315,6 +1379,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/instance/{instance}/message/list": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive list message with selectable options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a list message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/text": {
             "post": {
                 "security": [
@@ -1356,6 +1484,134 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.SendTextResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendButtons/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive buttons message (reply type) or PIX payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a buttons message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Buttons message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendList/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive list message with selectable options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a list message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListResponse"
                         }
                     },
                     "400": {
@@ -2145,6 +2401,92 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.SendButtonsRequest": {
+            "type": "object",
+            "required": [
+                "buttons",
+                "description",
+                "number"
+            ],
+            "properties": {
+                "buttons": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendButtonsRequestButton"
+                    }
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footer": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendButtonsRequestButton": {
+            "type": "object",
+            "required": [
+                "displayText",
+                "type"
+            ],
+            "properties": {
+                "currency": {
+                    "description": "PIX fields",
+                    "type": "string"
+                },
+                "displayText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "keyType": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendButtonsResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendChatPresenceRequest": {
             "type": "object",
             "properties": {
@@ -2236,6 +2578,99 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "base64": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequest": {
+            "type": "object",
+            "required": [
+                "description",
+                "number",
+                "sections"
+            ],
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "sections": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendListRequestSection"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequestRow": {
+            "type": "object",
+            "required": [
+                "rowId",
+                "title"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "rowId": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequestSection": {
+            "type": "object",
+            "required": [
+                "rows"
+            ],
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendListRequestRow"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -2569,6 +3004,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "byEvents": {
+                    "type": "boolean"
+                },
+                "enabled": {
                     "type": "boolean"
                 },
                 "events": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1181,6 +1181,70 @@
                 }
             }
         },
+        "/instance/{instance}/message/buttons": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive buttons message (reply type) or PIX payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a buttons message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Buttons message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/document": {
             "post": {
                 "security": [
@@ -1309,6 +1373,70 @@
                 }
             }
         },
+        "/instance/{instance}/message/list": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive list message with selectable options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a list message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/text": {
             "post": {
                 "security": [
@@ -1350,6 +1478,134 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.SendTextResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendButtons/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive buttons message (reply type) or PIX payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a buttons message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Buttons message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendButtonsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendList/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends an interactive list message with selectable options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a list message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List message parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendListResponse"
                         }
                     },
                     "400": {
@@ -2139,6 +2395,92 @@
                 }
             }
         },
+        "dto.SendButtonsRequest": {
+            "type": "object",
+            "required": [
+                "buttons",
+                "description",
+                "number"
+            ],
+            "properties": {
+                "buttons": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendButtonsRequestButton"
+                    }
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footer": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendButtonsRequestButton": {
+            "type": "object",
+            "required": [
+                "displayText",
+                "type"
+            ],
+            "properties": {
+                "currency": {
+                    "description": "PIX fields",
+                    "type": "string"
+                },
+                "displayText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "keyType": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendButtonsResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendChatPresenceRequest": {
             "type": "object",
             "properties": {
@@ -2230,6 +2572,99 @@
             "type": "object",
             "properties": {
                 "base64": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequest": {
+            "type": "object",
+            "required": [
+                "description",
+                "number",
+                "sections"
+            ],
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "sections": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendListRequestSection"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequestRow": {
+            "type": "object",
+            "required": [
+                "rowId",
+                "title"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "rowId": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListRequestSection": {
+            "type": "object",
+            "required": [
+                "rows"
+            ],
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendListRequestRow"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendListResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -2563,6 +2998,9 @@
                     "type": "boolean"
                 },
                 "byEvents": {
+                    "type": "boolean"
+                },
+                "enabled": {
                     "type": "boolean"
                 },
                 "events": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -337,6 +337,65 @@ definitions:
       waveform:
         type: string
     type: object
+  dto.SendButtonsRequest:
+    properties:
+      buttons:
+        items:
+          $ref: '#/definitions/dto.SendButtonsRequestButton'
+        maxItems: 3
+        minItems: 1
+        type: array
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      description:
+        type: string
+      footer:
+        type: string
+      number:
+        type: string
+      title:
+        type: string
+    required:
+    - buttons
+    - description
+    - number
+    type: object
+  dto.SendButtonsRequestButton:
+    properties:
+      currency:
+        description: PIX fields
+        type: string
+      displayText:
+        type: string
+      id:
+        type: string
+      key:
+        type: string
+      keyType:
+        type: string
+      name:
+        type: string
+      type:
+        type: string
+    required:
+    - displayText
+    - type
+    type: object
+  dto.SendButtonsResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
+    type: object
   dto.SendChatPresenceRequest:
     properties:
       delay:
@@ -399,6 +458,69 @@ definitions:
   dto.SendDocumentResponseData:
     properties:
       base64:
+        type: string
+    type: object
+  dto.SendListRequest:
+    properties:
+      buttonText:
+        type: string
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      description:
+        type: string
+      footerText:
+        type: string
+      number:
+        type: string
+      sections:
+        items:
+          $ref: '#/definitions/dto.SendListRequestSection'
+        minItems: 1
+        type: array
+      title:
+        type: string
+    required:
+    - description
+    - number
+    - sections
+    type: object
+  dto.SendListRequestRow:
+    properties:
+      description:
+        type: string
+      rowId:
+        type: string
+      title:
+        type: string
+    required:
+    - rowId
+    - title
+    type: object
+  dto.SendListRequestSection:
+    properties:
+      rows:
+        items:
+          $ref: '#/definitions/dto.SendListRequestRow'
+        minItems: 1
+        type: array
+      title:
+        type: string
+    required:
+    - rows
+    type: object
+  dto.SendListResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
         type: string
     type: object
   dto.SendMediaRequest:
@@ -621,6 +743,8 @@ definitions:
       base64:
         type: boolean
       byEvents:
+        type: boolean
+      enabled:
         type: boolean
       events:
         items:
@@ -1126,6 +1250,47 @@ paths:
       summary: Send an audio message
       tags:
       - Message
+  /instance/{instance}/message/buttons:
+    post:
+      consumes:
+      - application/json
+      description: Sends an interactive buttons message (reply type) or PIX payment
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Buttons message parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendButtonsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendButtonsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a buttons message
+      tags:
+      - Message
   /instance/{instance}/message/document:
     post:
       consumes:
@@ -1206,6 +1371,47 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send an image
+      tags:
+      - Message
+  /instance/{instance}/message/list:
+    post:
+      consumes:
+      - application/json
+      description: Sends an interactive list message with selectable options
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: List message parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendListRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a list message
       tags:
       - Message
   /instance/{instance}/message/text:
@@ -1531,6 +1737,88 @@ paths:
       summary: Update an existing instance
       tags:
       - Instance
+  /message/sendButtons/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends an interactive buttons message (reply type) or PIX payment
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Buttons message parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendButtonsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendButtonsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a buttons message
+      tags:
+      - Message
+  /message/sendList/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends an interactive list message with selectable options
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: List message parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendListRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a list message
+      tags:
+      - Message
   /message/sendMedia/{instance}:
     post:
       consumes:

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -433,6 +433,10 @@ func (s *Whatsmiau) parseWAMessage(m *waE2E.Message) (string, *WookMessageRaw, *
 				SelectedRowId: selectedRowID,
 			},
 		}
+	} else if br := m.GetButtonsResponseMessage(); br != nil {
+		messageType = "buttonsResponseMessage"
+		raw.Conversation = br.GetSelectedDisplayText()
+		ci = br.GetContextInfo()
 	} else if img := m.GetImageMessage(); img != nil {
 		messageType = "imageMessage"
 		ci = img.GetContextInfo()

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -2,11 +2,14 @@ package whatsmiau
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"go.mau.fi/whatsmeow"
+	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
@@ -333,6 +336,377 @@ func (s *Whatsmiau) SendReaction(ctx context.Context, data *SendReactionRequest)
 	}
 
 	return &SendReactionResponse{
+		ID:        res.ID,
+		CreatedAt: res.Timestamp,
+	}, nil
+}
+
+// --- SendList ---
+
+type SendListSection struct {
+	Title string        `json:"title"`
+	Rows  []SendListRow `json:"rows"`
+}
+
+type SendListRow struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	RowId       string `json:"row_id"`
+}
+
+type SendListRequest struct {
+	InstanceID  string            `json:"instance_id"`
+	RemoteJID   *types.JID        `json:"remote_jid"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	ButtonText  string            `json:"button_text"`
+	FooterText  string            `json:"footer_text"`
+	Sections    []SendListSection `json:"sections"`
+}
+
+type SendListResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (s *Whatsmiau) SendList(ctx context.Context, data *SendListRequest) (*SendListResponse, error) {
+	client, ok := s.clients.Load(data.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
+	// Build protobuf sections
+	protoSections := make([]*waE2E.ListMessage_Section, 0, len(data.Sections))
+	for _, sec := range data.Sections {
+		rows := make([]*waE2E.ListMessage_Row, 0, len(sec.Rows))
+		for _, row := range sec.Rows {
+			rowTitle := strings.TrimSpace(row.Title)
+			if rowTitle == "" {
+				continue
+			}
+			rowID := strings.TrimSpace(row.RowId)
+			if rowID == "" {
+				rowID = rowTitle
+			}
+			protoRow := &waE2E.ListMessage_Row{
+				RowID: proto.String(rowID),
+				Title: proto.String(rowTitle),
+			}
+			if desc := strings.TrimSpace(row.Description); desc != "" {
+				protoRow.Description = proto.String(desc)
+			}
+			rows = append(rows, protoRow)
+		}
+		if len(rows) == 0 {
+			continue
+		}
+		section := &waE2E.ListMessage_Section{Rows: rows}
+		if secTitle := strings.TrimSpace(sec.Title); secTitle != "" {
+			section.Title = proto.String(secTitle)
+		}
+		protoSections = append(protoSections, section)
+	}
+	if len(protoSections) == 0 {
+		return nil, fmt.Errorf("valid sections with rows are required")
+	}
+
+	buttonText := strings.TrimSpace(data.ButtonText)
+	if buttonText == "" {
+		buttonText = "Select"
+	}
+
+	listMsg := &waE2E.ListMessage{
+		Description: proto.String(data.Description),
+		ButtonText:  proto.String(buttonText),
+		ListType:    waE2E.ListMessage_SINGLE_SELECT.Enum(),
+		Sections:    protoSections,
+	}
+	if data.Title != "" {
+		listMsg.Title = proto.String(data.Title)
+	}
+	if data.FooterText != "" {
+		listMsg.FooterText = proto.String(data.FooterText)
+	}
+
+	// Wrap in FutureProofMessage (CRITICAL for rendering)
+	message := &waE2E.Message{
+		DocumentWithCaptionMessage: &waE2E.FutureProofMessage{
+			Message: &waE2E.Message{
+				ListMessage: listMsg,
+			},
+		},
+	}
+
+	// Extra binary nodes for list
+	extraNodes := []waBinary.Node{{
+		Tag: "biz",
+		Content: []waBinary.Node{{
+			Tag: "list",
+			Attrs: waBinary.Attrs{
+				"type": "product_list",
+				"v":    "2",
+			},
+		}},
+	}}
+
+	res, err := client.SendMessage(ctx, *data.RemoteJID, message, whatsmeow.SendRequestExtra{
+		AdditionalNodes: &extraNodes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendListResponse{
+		ID:        res.ID,
+		CreatedAt: res.Timestamp,
+	}, nil
+}
+
+// --- SendButtons ---
+
+type SendButtonItem struct {
+	DisplayText string `json:"display_text"`
+	Id          string `json:"id"`
+}
+
+type SendButtonsRequestData struct {
+	InstanceID  string           `json:"instance_id"`
+	RemoteJID   *types.JID       `json:"remote_jid"`
+	Title       string           `json:"title"`
+	Description string           `json:"description"`
+	Footer      string           `json:"footer"`
+	Buttons     []SendButtonItem `json:"buttons"`
+}
+
+type SendButtonsResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (s *Whatsmiau) SendButtons(ctx context.Context, data *SendButtonsRequestData) (*SendButtonsResponse, error) {
+	client, ok := s.clients.Load(data.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
+	// Build buttons
+	protoButtons := make([]*waE2E.ButtonsMessage_Button, 0, len(data.Buttons))
+	for _, btn := range data.Buttons {
+		title := strings.TrimSpace(btn.DisplayText)
+		if title == "" {
+			continue
+		}
+		buttonID := strings.TrimSpace(btn.Id)
+		if buttonID == "" {
+			buttonID = title
+		}
+		protoButtons = append(protoButtons, &waE2E.ButtonsMessage_Button{
+			ButtonID: proto.String(buttonID),
+			ButtonText: &waE2E.ButtonsMessage_Button_ButtonText{
+				DisplayText: proto.String(title),
+			},
+			Type:           waE2E.ButtonsMessage_Button_RESPONSE.Enum(),
+			NativeFlowInfo: &waE2E.ButtonsMessage_Button_NativeFlowInfo{},
+		})
+	}
+	if len(protoButtons) == 0 {
+		return nil, fmt.Errorf("valid buttons are required")
+	}
+
+	// Build ButtonsMessage
+	buttonsMsg := &waE2E.ButtonsMessage{
+		ContentText: proto.String(data.Description),
+		HeaderType:  waE2E.ButtonsMessage_EMPTY.Enum(),
+		Buttons:     protoButtons,
+	}
+	if data.Title != "" {
+		buttonsMsg.HeaderType = waE2E.ButtonsMessage_TEXT.Enum()
+		buttonsMsg.Header = &waE2E.ButtonsMessage_Text{Text: data.Title}
+	}
+	if data.Footer != "" {
+		buttonsMsg.FooterText = proto.String(data.Footer)
+	}
+
+	// Wrap in FutureProofMessage (CRITICAL for rendering)
+	message := &waE2E.Message{
+		DocumentWithCaptionMessage: &waE2E.FutureProofMessage{
+			Message: &waE2E.Message{
+				ButtonsMessage: buttonsMsg,
+			},
+		},
+	}
+
+	// Extra binary nodes for buttons
+	extraNodes := []waBinary.Node{{
+		Tag: "biz",
+		Content: []waBinary.Node{{
+			Tag: "interactive",
+			Attrs: waBinary.Attrs{
+				"type": "native_flow",
+				"v":    "1",
+			},
+			Content: []waBinary.Node{{
+				Tag: "native_flow",
+				Attrs: waBinary.Attrs{
+					"v":    "9",
+					"name": "mixed",
+				},
+			}},
+		}},
+	}}
+
+	res, err := client.SendMessage(ctx, *data.RemoteJID, message, whatsmeow.SendRequestExtra{
+		AdditionalNodes: &extraNodes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendButtonsResponse{
+		ID:        res.ID,
+		CreatedAt: res.Timestamp,
+	}, nil
+}
+
+// --- SendPixPayment ---
+
+type SendPixPaymentRequest struct {
+	InstanceID   string     `json:"instance_id"`
+	RemoteJID    *types.JID `json:"remote_jid"`
+	PixKey       string     `json:"pix_key"`
+	PixKeyType   string     `json:"pix_key_type"`
+	MerchantName string     `json:"merchant_name"`
+	DisplayText  string     `json:"display_text"`
+	Currency     string     `json:"currency"`
+}
+
+type SendPixPaymentResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (s *Whatsmiau) SendPixPayment(ctx context.Context, data *SendPixPaymentRequest) (*SendPixPaymentResponse, error) {
+	client, ok := s.clients.Load(data.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
+	currency := data.Currency
+	if currency == "" {
+		currency = "BRL"
+	}
+	displayText := data.DisplayText
+	if displayText == "" {
+		displayText = "Pagar com PIX"
+	}
+	referenceID := fmt.Sprintf("PIX%d", time.Now().UnixMilli())
+
+	// Map Evolution API keyType to WhatsApp protocol key_type
+	keyType := strings.ToUpper(data.PixKeyType)
+	if keyType == "RANDOM" {
+		keyType = "EVP"
+	}
+
+	buttonParams := map[string]interface{}{
+		"display_text": displayText,
+		"currency":     currency,
+		"total_amount": map[string]interface{}{
+			"value":  0,
+			"offset": 100,
+		},
+		"reference_id": referenceID,
+		"type":         "physical-goods",
+		"order": map[string]interface{}{
+			"status": "pending",
+			"subtotal": map[string]interface{}{
+				"value":  0,
+				"offset": 100,
+			},
+			"order_type": "ORDER",
+			"items": []map[string]interface{}{
+				{
+					"retailer_id": "0",
+					"product_id":  "0",
+					"name":        displayText,
+					"amount": map[string]interface{}{
+						"value":  0,
+						"offset": 100,
+					},
+					"quantity": 1,
+				},
+			},
+		},
+		"payment_settings": []map[string]interface{}{
+			{
+				"type": "pix_static_code",
+				"pix_static_code": map[string]interface{}{
+					"merchant_name": data.MerchantName,
+					"key":           data.PixKey,
+					"key_type":      keyType,
+				},
+			},
+		},
+	}
+
+	buttonParamsJSON, err := json.Marshal(buttonParams)
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	interactiveMsg := &waE2E.InteractiveMessage{
+		InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+			NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+				MessageVersion: proto.Int32(1),
+				Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+					{
+						Name:             proto.String("payment_info"),
+						ButtonParamsJSON: proto.String(string(buttonParamsJSON)),
+					},
+				},
+			},
+		},
+	}
+
+	// PIX: InteractiveMessage directly (NO FutureProofMessage wrapper)
+	message := &waE2E.Message{InteractiveMessage: interactiveMsg}
+
+	// Biz node: simple native_flow_name attribute (flat, 1 level)
+	extraNodes := []waBinary.Node{{
+		Tag: "biz",
+		Attrs: waBinary.Attrs{
+			"native_flow_name": "payment_info",
+		},
+	}}
+
+	res, err := client.SendMessage(ctx, *data.RemoteJID, message, whatsmeow.SendRequestExtra{
+		AdditionalNodes: &extraNodes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendPixPaymentResponse{
 		ID:        res.ID,
 		CreatedAt: res.Timestamp,
 	}, nil

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"regexp"
 	"time"
@@ -396,6 +398,236 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 		Status:           "sent",
 		MessageType:      "reactionMessage",
 		MessageTimestamp: int(res.CreatedAt.UnixMicro() / 1000),
+		InstanceId:       request.InstanceID,
+	})
+}
+
+// SendList godoc
+// @Summary      Send a list message
+// @Description  Sends an interactive list message with selectable options
+// @Tags         Message
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string              true  "Instance ID"
+// @Param        body      body      dto.SendListRequest  true  "List message parameters"
+// @Success      200       {object}  dto.SendListResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /instance/{instance}/message/list [post]
+// @Router       /message/sendList/{instance} [post]
+func (s *Message) SendList(ctx echo.Context) error {
+	var request dto.SendListRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	jid, err := numberToJid(request.Number)
+	if err != nil {
+		zap.L().Error("error converting number to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
+	}
+
+	// Convert DTO sections to service-layer sections
+	var sections []whatsmiau.SendListSection
+	for _, sec := range request.Sections {
+		var rows []whatsmiau.SendListRow
+		for _, r := range sec.Rows {
+			rows = append(rows, whatsmiau.SendListRow{
+				Title:       r.Title,
+				Description: r.Description,
+				RowId:       r.RowId,
+			})
+		}
+		sections = append(sections, whatsmiau.SendListSection{
+			Title: sec.Title,
+			Rows:  rows,
+		})
+	}
+
+	sendData := &whatsmiau.SendListRequest{
+		InstanceID:  request.InstanceID,
+		RemoteJID:   jid,
+		Title:       request.Title,
+		Description: request.Description,
+		ButtonText:  request.ButtonText,
+		FooterText:  request.FooterText,
+		Sections:    sections,
+	}
+
+	c := ctx.Request().Context()
+	if err := s.whatsmiau.ChatPresence(&whatsmiau.ChatPresenceRequest{
+		InstanceID: request.InstanceID,
+		RemoteJID:  jid,
+		Presence:   types.ChatPresenceComposing,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.ChatPresence", zap.Error(err))
+	} else {
+		time.Sleep(time.Millisecond * time.Duration(request.Delay))
+	}
+
+	res, err := s.whatsmiau.SendList(c, sendData)
+	if err != nil {
+		zap.L().Error("Whatsmiau.SendList failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to send list")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.SendListResponse{
+		Key: dto.MessageResponseKey{
+			RemoteJid: request.Number,
+			FromMe:    true,
+			Id:        res.ID,
+		},
+		Status:           "sent",
+		MessageType:      "listMessage",
+		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		InstanceId:       request.InstanceID,
+	})
+}
+
+// SendButtons godoc
+// @Summary      Send a buttons message
+// @Description  Sends an interactive buttons message (reply type) or PIX payment
+// @Tags         Message
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                  true  "Instance ID"
+// @Param        body      body      dto.SendButtonsRequest   true  "Buttons message parameters"
+// @Success      200       {object}  dto.SendButtonsResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /instance/{instance}/message/buttons [post]
+// @Router       /message/sendButtons/{instance} [post]
+func (s *Message) SendButtons(ctx echo.Context) error {
+	var request dto.SendButtonsRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	jid, err := numberToJid(request.Number)
+	if err != nil {
+		zap.L().Error("error converting number to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
+	}
+
+	// Classify button types (already validated by oneof=reply pix)
+	var hasReply, hasPix bool
+	for _, btn := range request.Buttons {
+		switch btn.Type {
+		case "reply":
+			hasReply = true
+		case "pix":
+			hasPix = true
+		}
+	}
+
+	c := ctx.Request().Context()
+	if err := s.whatsmiau.ChatPresence(&whatsmiau.ChatPresenceRequest{
+		InstanceID: request.InstanceID,
+		RemoteJID:  jid,
+		Presence:   types.ChatPresenceComposing,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.ChatPresence", zap.Error(err))
+	} else {
+		time.Sleep(time.Millisecond * time.Duration(request.Delay))
+	}
+
+	// PIX flow: if any button is pix, use PIX handler
+	if hasPix {
+		return s.sendPixButtons(ctx, c, request, jid)
+	}
+
+	// Reply buttons flow
+	if hasReply {
+		return s.sendReplyButtons(ctx, c, request, jid)
+	}
+
+	return utils.HTTPFail(ctx, http.StatusBadRequest, fmt.Errorf("no valid buttons"), "no valid buttons provided")
+}
+
+func (s *Message) sendReplyButtons(ctx echo.Context, c context.Context, request dto.SendButtonsRequest, jid *types.JID) error {
+	var buttons []whatsmiau.SendButtonItem
+	for _, b := range request.Buttons {
+		buttons = append(buttons, whatsmiau.SendButtonItem{
+			DisplayText: b.DisplayText,
+			Id:          b.Id,
+		})
+	}
+
+	sendData := &whatsmiau.SendButtonsRequestData{
+		InstanceID:  request.InstanceID,
+		RemoteJID:   jid,
+		Title:       request.Title,
+		Description: request.Description,
+		Footer:      request.Footer,
+		Buttons:     buttons,
+	}
+
+	res, err := s.whatsmiau.SendButtons(c, sendData)
+	if err != nil {
+		zap.L().Error("Whatsmiau.SendButtons failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to send buttons")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.SendButtonsResponse{
+		Key: dto.MessageResponseKey{
+			RemoteJid: request.Number,
+			FromMe:    true,
+			Id:        res.ID,
+		},
+		Status:           "sent",
+		MessageType:      "buttonsMessage",
+		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		InstanceId:       request.InstanceID,
+	})
+}
+
+func (s *Message) sendPixButtons(ctx echo.Context, c context.Context, request dto.SendButtonsRequest, jid *types.JID) error {
+	// Find the pix button
+	var pixBtn dto.SendButtonsRequestButton
+	for _, b := range request.Buttons {
+		if b.Type == "pix" {
+			pixBtn = b
+			break
+		}
+	}
+
+	sendData := &whatsmiau.SendPixPaymentRequest{
+		InstanceID:   request.InstanceID,
+		RemoteJID:    jid,
+		PixKey:       pixBtn.Key,
+		PixKeyType:   pixBtn.KeyType,
+		MerchantName: pixBtn.Name,
+		DisplayText:  pixBtn.DisplayText,
+		Currency:     pixBtn.Currency,
+	}
+
+	res, err := s.whatsmiau.SendPixPayment(c, sendData)
+	if err != nil {
+		zap.L().Error("Whatsmiau.SendPixPayment failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to send pix payment")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.SendButtonsResponse{
+		Key: dto.MessageResponseKey{
+			RemoteJid: request.Number,
+			FromMe:    true,
+			Id:        res.ID,
+		},
+		Status:           "sent",
+		MessageType:      "buttonsMessage",
+		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
 		InstanceId:       request.InstanceID,
 	})
 }

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -191,3 +191,66 @@ type SendReactionResponse struct {
 	Source           string             `json:"source,omitempty"`
 	Status           string             `json:"status,omitempty"`
 }
+
+// --- sendList DTOs ---
+
+type SendListRequestSection struct {
+	Title string               `json:"title,omitempty"`
+	Rows  []SendListRequestRow `json:"rows,omitempty" validate:"required,min=1,dive"`
+}
+
+type SendListRequestRow struct {
+	Title       string `json:"title,omitempty" validate:"required"`
+	Description string `json:"description,omitempty"`
+	RowId       string `json:"rowId,omitempty" validate:"required"`
+}
+
+type SendListRequest struct {
+	InstanceID  string                   `param:"instance" validate:"required" swaggerignore:"true"`
+	Number      string                   `json:"number,omitempty" validate:"required"`
+	Title       string                   `json:"title,omitempty"`
+	Description string                   `json:"description,omitempty" validate:"required"`
+	ButtonText  string                   `json:"buttonText,omitempty"`
+	FooterText  string                   `json:"footerText,omitempty"`
+	Sections    []SendListRequestSection `json:"sections,omitempty" validate:"required,min=1,dive"`
+	Delay       int                      `json:"delay,omitempty" validate:"omitempty,min=0,max=300000"`
+}
+
+type SendListResponse struct {
+	Key              MessageResponseKey `json:"key"`
+	Status           string             `json:"status"`
+	MessageType      string             `json:"messageType"`
+	MessageTimestamp int                `json:"messageTimestamp"`
+	InstanceId       string             `json:"instanceId"`
+}
+
+// --- sendButtons DTOs ---
+
+type SendButtonsRequestButton struct {
+	Type        string `json:"type,omitempty" validate:"required,oneof=reply pix"`
+	DisplayText string `json:"displayText,omitempty" validate:"required"`
+	Id          string `json:"id,omitempty"`
+	// PIX fields
+	Currency string `json:"currency,omitempty"`
+	Name     string `json:"name,omitempty" validate:"required_if=Type pix"`
+	KeyType  string `json:"keyType,omitempty" validate:"required_if=Type pix"`
+	Key      string `json:"key,omitempty" validate:"required_if=Type pix"`
+}
+
+type SendButtonsRequest struct {
+	InstanceID  string                     `param:"instance" validate:"required" swaggerignore:"true"`
+	Number      string                     `json:"number,omitempty" validate:"required"`
+	Title       string                     `json:"title,omitempty"`
+	Description string                     `json:"description,omitempty" validate:"required"`
+	Footer      string                     `json:"footer,omitempty"`
+	Buttons     []SendButtonsRequestButton `json:"buttons,omitempty" validate:"required,min=1,max=3,dive"`
+	Delay       int                        `json:"delay,omitempty" validate:"omitempty,min=0,max=300000"`
+}
+
+type SendButtonsResponse struct {
+	Key              MessageResponseKey `json:"key"`
+	Status           string             `json:"status"`
+	MessageType      string             `json:"messageType"`
+	MessageTimestamp int                `json:"messageTimestamp"`
+	InstanceId       string             `json:"instanceId"`
+}

--- a/server/routes/message.go
+++ b/server/routes/message.go
@@ -16,6 +16,8 @@ func Message(group *echo.Group) {
 	group.POST("/audio", controller.SendAudio)
 	group.POST("/document", controller.SendDocument)
 	group.POST("/image", controller.SendImage)
+	group.POST("/list", controller.SendList)
+	group.POST("/buttons", controller.SendButtons)
 }
 
 func MessageEVO(group *echo.Group) {
@@ -27,4 +29,6 @@ func MessageEVO(group *echo.Group) {
 	group.POST("/sendWhatsAppAudio/:instance", controller.SendAudio) // is always whatsapp 🤣
 	group.POST("/sendMedia/:instance", controller.SendMedia)
 	group.POST("/sendReaction/:instance", controller.SendReaction)
+	group.POST("/sendList/:instance", controller.SendList)
+	group.POST("/sendButtons/:instance", controller.SendButtons)
 }


### PR DESCRIPTION
Implement interactive message endpoints with Evolution API v2.3 compatibility:
- sendList: ListMessage wrapped in FutureProofMessage with binary extra nodes
- sendButtons (reply): ButtonsMessage with NativeFlowInfo wrapped in FutureProofMessage
- sendButtons (pix): InteractiveMessage with NativeFlowMessage for PIX payments
- Handle ButtonsResponseMessage in webhook event emitter
- Full DTO validation with validator/v10 (required_if for PIX fields, oneof for types)