### PR TITLE
feat: add messages.delete event for WhatsApp revoke (delete for every…

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The application can send webhook events for the following actions:
 |-------------------|-----------------------------------------------------|
 | `MESSAGES_UPSERT` | Triggered when a new message is received.           |
 | `MESSAGES_UPDATE` | Triggered when a message status changes (e.g., read). |
+| `MESSAGES_DELETE` | Triggered when a message is deleted for everyone.   |
 | `CONTACTS_UPSERT` | Triggered when a contact is created or updated.     |
 
 

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -195,6 +195,13 @@ func (s *Whatsmiau) handleLoggedOut(id string) {
 	s.clients.Delete(id)
 }
 func (s *Whatsmiau) handleMessageEvent(id string, instance *models.Instance, e *events.Message, eventMap map[string]bool) {
+	if e.Message != nil {
+		if pm := e.Message.GetProtocolMessage(); pm != nil && pm.GetType() == waE2E.ProtocolMessage_REVOKE {
+			s.handleMessageDeleteEvent(id, instance, e, eventMap)
+			return
+		}
+	}
+
 	if !eventMap["MESSAGES_UPSERT"] {
 		return
 	}
@@ -233,6 +240,55 @@ func (s *Whatsmiau) handleMessageEvent(id string, instance *models.Instance, e *
 	}
 
 	s.emit(wookMessage, instance.Webhook.Url)
+}
+
+func (s *Whatsmiau) handleMessageDeleteEvent(id string, instance *models.Instance, e *events.Message, eventMap map[string]bool) {
+	if !eventMap["MESSAGES_DELETE"] {
+		return
+	}
+
+	if canIgnoreGroup(e, instance) {
+		return
+	}
+
+	if canIgnoreMessage(e) {
+		return
+	}
+
+	pm := e.Message.GetProtocolMessage()
+	pKey := pm.GetKey()
+	if pKey == nil {
+		return
+	}
+
+	ctx, c := context.WithTimeout(context.Background(), time.Second*5)
+	defer c()
+
+	remoteJid, _ := s.GetJidLid(ctx, id, e.Info.Chat)
+
+	keyRemoteJid := pKey.GetRemoteJID()
+	if keyRemoteJid == "" {
+		keyRemoteJid = remoteJid
+	}
+
+	deleteData := &WookMessageDeleteData{
+		Id:          pKey.GetID(),
+		RemoteJid:   keyRemoteJid,
+		FromMe:      pKey.GetFromMe(),
+		Participant: pKey.GetParticipant(),
+		Status:      "DELETED",
+		InstanceId:  instance.ID,
+	}
+
+	wookEvent := &WookEvent[WookMessageDeleteData]{
+		Instance: instance.ID,
+		Data:     deleteData,
+		DateTime: time.Now(),
+		Event:    WookMessagesDelete,
+	}
+
+	zap.L().Debug("message delete event", zap.String("instance", id), zap.Any("data", deleteData))
+	s.emit(wookEvent, instance.Webhook.Url)
 }
 
 func (s *Whatsmiau) handleReceiptEvent(id string, instance *models.Instance, e *events.Receipt, eventMap map[string]bool) {

--- a/lib/whatsmiau/models.go
+++ b/lib/whatsmiau/models.go
@@ -9,9 +9,10 @@ import (
 type Wook string
 
 const (
-	WookMessagesUpsert Wook = "messages.upsert"
-	WookMessagesUpdate Wook = "messages.update"
-	WookContactsUpsert Wook = "contacts.upsert"
+	WookMessagesUpsert  Wook = "messages.upsert"
+	WookMessagesUpdate  Wook = "messages.update"
+	WookMessagesDelete  Wook = "messages.delete"
+	WookContactsUpsert  Wook = "contacts.upsert"
 )
 
 type WookEvent[data any] struct {
@@ -244,6 +245,15 @@ const (
 	MessageStatusDeliveryAck WookMessageUpdateStatus = "DELIVERY_ACK"
 	MessageStatusRead        WookMessageUpdateStatus = "READ"
 )
+
+type WookMessageDeleteData struct {
+	Id          string `json:"id,omitempty"`
+	RemoteJid   string `json:"remoteJid,omitempty"`
+	FromMe      bool   `json:"fromMe"`
+	Participant string `json:"participant,omitempty"`
+	Status      string `json:"status,omitempty"`
+	InstanceId  string `json:"instanceId,omitempty"`
+}
 
 type WookMessageUpdateData struct {
 	MessageId      string                  `json:"messageId,omitempty"`


### PR DESCRIPTION
…one)

Intercepts ProtocolMessage_REVOKE at the top of handleMessageEvent and dispatches a messages.delete webhook event with the same payload format as evolution-api: { id, remoteJid, fromMe, participant, status: DELETED }.