### PR TITLE
feat: message delete

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -47,6 +47,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/chat/deleteMessageForEveryone/{instance}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a message in the chat so it is deleted for all participants.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Delete message for everyone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message to revoke",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.DeleteMessageForEveryoneRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty object on success",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/chat/markMessageAsRead/{instance}": {
             "post": {
                 "security": [
@@ -974,6 +1039,71 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/chat/deleteMessageForEveryone": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a message in the chat so it is deleted for all participants.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Delete message for everyone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message to revoke",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.DeleteMessageForEveryoneRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty object on success",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
                         }
@@ -2076,6 +2206,27 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DeleteMessageForEveryoneRequest": {
+            "type": "object",
+            "required": [
+                "id",
+                "remoteJid"
+            ],
+            "properties": {
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -41,6 +41,71 @@
                 }
             }
         },
+        "/chat/deleteMessageForEveryone/{instance}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a message in the chat so it is deleted for all participants.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Delete message for everyone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message to revoke",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.DeleteMessageForEveryoneRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty object on success",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/chat/markMessageAsRead/{instance}": {
             "post": {
                 "security": [
@@ -968,6 +1033,71 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/chat/deleteMessageForEveryone": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a message in the chat so it is deleted for all participants.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Delete message for everyone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message to revoke",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.DeleteMessageForEveryoneRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty object on success",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
                         }
@@ -2070,6 +2200,27 @@
             "type": "object",
             "properties": {
                 "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DeleteMessageForEveryoneRequest": {
+            "type": "object",
+            "required": [
+                "id",
+                "remoteJid"
+            ],
+            "properties": {
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -123,6 +123,20 @@ definitions:
       message:
         type: string
     type: object
+  dto.DeleteMessageForEveryoneRequest:
+    properties:
+      fromMe:
+        type: boolean
+      id:
+        type: string
+      participant:
+        type: string
+      remoteJid:
+        type: string
+    required:
+    - id
+    - remoteJid
+    type: object
   dto.DeviceListMetadata:
     properties:
       recipientKeyHash:
@@ -795,6 +809,48 @@ paths:
       summary: API health check and info
       tags:
       - Root
+  /chat/deleteMessageForEveryone/{instance}:
+    delete:
+      consumes:
+      - application/json
+      description: Revokes a message in the chat so it is deleted for all participants.
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Message to revoke
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.DeleteMessageForEveryoneRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Empty object on success
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Delete message for everyone
+      tags:
+      - Chat
   /chat/markMessageAsRead/{instance}:
     post:
       consumes:
@@ -1123,6 +1179,48 @@ paths:
       summary: Get instance connection state
       tags:
       - Instance
+  /instance/{instance}/chat/deleteMessageForEveryone:
+    delete:
+      consumes:
+      - application/json
+      description: Revokes a message in the chat so it is deleted for all participants.
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Message to revoke
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.DeleteMessageForEveryoneRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Empty object on success
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Delete message for everyone
+      tags:
+      - Chat
   /instance/{instance}/chat/presence:
     post:
       consumes:

--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -1,6 +1,7 @@
 package whatsmiau
 
 import (
+	"fmt"
 	"time"
 
 	"go.mau.fi/whatsmeow"
@@ -114,4 +115,46 @@ func (s *Whatsmiau) resolveJID(ctx context.Context, client *whatsmeow.Client, ji
 	}
 
 	return jid
+}
+
+type DeleteMessageForEveryoneRequest struct {
+	InstanceID     string     `json:"instance_id"`
+	RemoteJID      *types.JID `json:"remote_jid"`
+	MessageID      string     `json:"message_id"`
+	FromMe         bool       `json:"from_me"`
+	ParticipantJID *types.JID `json:"participant_jid,omitempty"`
+}
+
+func (s *Whatsmiau) DeleteMessageForEveryone(ctx context.Context, req *DeleteMessageForEveryoneRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	if client.Store == nil || client.Store.ID == nil {
+		return fmt.Errorf("device is not connected")
+	}
+	if req.RemoteJID == nil {
+		return fmt.Errorf("remote_jid is required")
+	}
+	if req.MessageID == "" {
+		return fmt.Errorf("message id is required")
+	}
+
+	chat := s.resolveJID(ctx, client, *req.RemoteJID)
+
+	var sender types.JID
+	if req.FromMe {
+		sender = types.EmptyJID
+	} else if chat.Server == types.GroupServer {
+		if req.ParticipantJID == nil || req.ParticipantJID.IsEmpty() {
+			return fmt.Errorf("participant is required when deleting another user's message in a group")
+		}
+		sender = s.resolveJID(ctx, client, *req.ParticipantJID)
+	} else {
+		sender = chat
+	}
+
+	msg := client.BuildRevoke(chat, sender, types.MessageID(req.MessageID))
+	_, err := client.SendMessage(ctx, chat, msg)
+	return err
 }

--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -133,22 +133,17 @@ func (s *Whatsmiau) DeleteMessageForEveryone(ctx context.Context, req *DeleteMes
 	if client.Store == nil || client.Store.ID == nil {
 		return fmt.Errorf("device is not connected")
 	}
-	if req.RemoteJID == nil {
-		return fmt.Errorf("remote_jid is required")
-	}
-	if req.MessageID == "" {
-		return fmt.Errorf("message id is required")
-	}
 
 	chat := s.resolveJID(ctx, client, *req.RemoteJID)
 
 	var sender types.JID
 	if req.FromMe {
-		sender = types.EmptyJID
-	} else if chat.Server == types.GroupServer {
-		if req.ParticipantJID == nil || req.ParticipantJID.IsEmpty() {
-			return fmt.Errorf("participant is required when deleting another user's message in a group")
+		if chat.Server == types.GroupServer {
+			sender = client.Store.ID.ToNonAD()
+		} else {
+			sender = types.EmptyJID
 		}
+	} else if chat.Server == types.GroupServer {
 		sender = s.resolveJID(ctx, client, *req.ParticipantJID)
 	} else {
 		sender = chat

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -187,3 +187,63 @@ func (s *Chat) NumberExists(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusOK, response)
 }
+
+// DeleteMessageForEveryone godoc
+// @Summary      Delete message for everyone
+// @Description  Revokes a message in the chat so it is deleted for all participants.
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                             true  "Instance ID"
+// @Param        body      body      dto.DeleteMessageForEveryoneRequest true  "Message to revoke"
+// @Success      200       {object}  map[string]interface{}             "Empty object on success"
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /instance/{instance}/chat/deleteMessageForEveryone [delete]
+// @Router       /chat/deleteMessageForEveryone/{instance} [delete]
+func (s *Chat) DeleteMessageForEveryone(ctx echo.Context) error {
+	var request dto.DeleteMessageForEveryoneRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	remoteJid, err := numberToJid(request.RemoteJid)
+	if err != nil {
+		zap.L().Error("error converting remoteJid to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid remoteJid format")
+	}
+
+	if !request.FromMe && remoteJid.Server == types.GroupServer && request.Participant == "" {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "participant is required when deleting another user's message in a group")
+	}
+
+	var participantJid *types.JID
+	if request.Participant != "" {
+		p, err := numberToJid(request.Participant)
+		if err != nil {
+			zap.L().Error("error converting participant to jid", zap.Error(err))
+			return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid participant format")
+		}
+		participantJid = p
+	}
+
+	c := ctx.Request().Context()
+	if err := s.whatsmiau.DeleteMessageForEveryone(c, &whatsmiau.DeleteMessageForEveryoneRequest{
+		InstanceID:       request.InstanceID,
+		RemoteJID:        remoteJid,
+		MessageID:        request.ID,
+		FromMe:           request.FromMe,
+		ParticipantJID:   participantJid,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.DeleteMessageForEveryone failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to delete message for everyone")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/server/dto/chat.go
+++ b/server/dto/chat.go
@@ -40,3 +40,11 @@ type SendChatPresenceResponse struct {
 type NumberExistsRequest struct {
 	Numbers []string `json:"numbers"     validate:"required,min=1,dive,required"`
 }
+
+type DeleteMessageForEveryoneRequest struct {
+	InstanceID  string `param:"instance" validate:"required" swaggerignore:"true"`
+	ID          string `json:"id" validate:"required"`
+	RemoteJid   string `json:"remoteJid" validate:"required"`
+	Participant string `json:"participant,omitempty" validate:"omitempty"`
+	FromMe      bool   `json:"fromMe"`
+}

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -14,6 +14,7 @@ func Chat(group *echo.Group) {
 
 	group.POST("/presence", controller.SendChatPresence)
 	group.POST("/read-messages", controller.ReadMessages)
+	group.DELETE("/deleteMessageForEveryone", controller.DeleteMessageForEveryone)
 }
 
 func ChatEVO(group *echo.Group) {
@@ -24,4 +25,5 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/markMessageAsRead/:instance", controller.ReadMessages)
 	group.POST("/sendPresence/:instance", controller.SendChatPresence)
 	group.POST("/whatsappNumbers/:instance", controller.NumberExists)
+	group.DELETE("/deleteMessageForEveryone/:instance", controller.DeleteMessageForEveryone)
 }


### PR DESCRIPTION
Add a message-deletion flow.

Expose HTTP route(s) and a chat controller handler that delete messages using instance id and message/chat identifiers. Add request/response DTOs with validation consistent with the API contract. Implement lib/whatsmiau logic that forwards the call to the whatsmeow client.