### PR TITLE
Adicionado status em tempo real via SSE para instancias no manager

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -201,6 +201,19 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 				return
 			}
 
+			switch evt.(type) {
+			case *events.Connected:
+				sseEvent := StatusEvent{Instance: id, State: "open"}
+				if client, ok := s.clients.Load(id); ok && client.Store.ID != nil {
+					sseEvent.Wuid = client.Store.ID.ToNonAD().String()
+				}
+				s.SSE.Broadcast(sseEvent)
+			case *events.Disconnected:
+				s.SSE.Broadcast(StatusEvent{Instance: id, State: "close"})
+			case *events.ConnectFailure:
+				s.SSE.Broadcast(StatusEvent{Instance: id, State: "close"})
+			}
+
 			if instance.Webhook.Enabled != nil && !*instance.Webhook.Enabled {
 				return
 			}
@@ -513,14 +526,6 @@ func (s *Whatsmiau) handlePushNameEvent(id string, instance *models.Instance, e 
 }
 
 func (s *Whatsmiau) handleConnectionUpdateEvent(id string, instance *models.Instance, state string, statusReason int, eventMap map[string]bool) {
-	sseEvent := StatusEvent{Instance: id, State: state}
-	if state == "open" {
-		if client, ok := s.clients.Load(id); ok && client.Store.ID != nil {
-			sseEvent.Wuid = client.Store.ID.ToNonAD().String()
-		}
-	}
-	s.SSE.Broadcast(sseEvent)
-
 	if !eventMap["CONNECTION_UPDATE"] {
 		return
 	}

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -254,7 +254,7 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 }
 
 func (s *Whatsmiau) handleLoggedOut(id string) {
-	s.SSE.Broadcast(StatusEvent{Instance: id, State: "closed"})
+	s.SSE.Broadcast(StatusEvent{Instance: id, State: "close"})
 
 	client, ok := s.clients.Load(id)
 	if ok {

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -241,6 +241,8 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 }
 
 func (s *Whatsmiau) handleLoggedOut(id string) {
+	s.SSE.Broadcast(StatusEvent{Instance: id, State: "closed"})
+
 	client, ok := s.clients.Load(id)
 	if ok {
 		if err := s.deleteDeviceIfExists(context.Background(), client); err != nil {
@@ -511,6 +513,14 @@ func (s *Whatsmiau) handlePushNameEvent(id string, instance *models.Instance, e 
 }
 
 func (s *Whatsmiau) handleConnectionUpdateEvent(id string, instance *models.Instance, state string, statusReason int, eventMap map[string]bool) {
+	sseEvent := StatusEvent{Instance: id, State: state}
+	if state == "open" {
+		if client, ok := s.clients.Load(id); ok && client.Store.ID != nil {
+			sseEvent.Wuid = client.Store.ID.ToNonAD().String()
+		}
+	}
+	s.SSE.Broadcast(sseEvent)
+
 	if !eventMap["CONNECTION_UPDATE"] {
 		return
 	}

--- a/lib/whatsmiau/sse.go
+++ b/lib/whatsmiau/sse.go
@@ -1,6 +1,13 @@
 package whatsmiau
 
-import "sync"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/labstack/echo/v4"
+)
 
 type StatusEvent struct {
 	Instance string `json:"instance"`
@@ -41,6 +48,30 @@ func (b *SSEBroadcaster) Broadcast(event StatusEvent) {
 		select {
 		case ch <- event:
 		default: // skip slow clients
+		}
+	}
+}
+
+func (b *SSEBroadcaster) Handler() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().Header().Set("Cache-Control", "no-cache")
+		c.Response().Header().Set("Connection", "keep-alive")
+		c.Response().WriteHeader(http.StatusOK)
+		c.Response().Flush()
+
+		ch := b.Register()
+		defer b.Unregister(ch)
+
+		for {
+			select {
+			case event := <-ch:
+				data, _ := json.Marshal(event)
+				fmt.Fprintf(c.Response(), "event: status\ndata: %s\n\n", data)
+				c.Response().Flush()
+			case <-c.Request().Context().Done():
+				return nil
+			}
 		}
 	}
 }

--- a/lib/whatsmiau/sse.go
+++ b/lib/whatsmiau/sse.go
@@ -1,0 +1,46 @@
+package whatsmiau
+
+import "sync"
+
+type StatusEvent struct {
+	Instance string `json:"instance"`
+	State    string `json:"state"`
+	Wuid     string `json:"wuid,omitempty"`
+}
+
+type SSEBroadcaster struct {
+	mu      sync.RWMutex
+	clients map[chan StatusEvent]struct{}
+}
+
+func NewSSEBroadcaster() *SSEBroadcaster {
+	return &SSEBroadcaster{
+		clients: make(map[chan StatusEvent]struct{}),
+	}
+}
+
+func (b *SSEBroadcaster) Register() chan StatusEvent {
+	ch := make(chan StatusEvent, 16)
+	b.mu.Lock()
+	b.clients[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+func (b *SSEBroadcaster) Unregister(ch chan StatusEvent) {
+	b.mu.Lock()
+	delete(b.clients, ch)
+	close(ch)
+	b.mu.Unlock()
+}
+
+func (b *SSEBroadcaster) Broadcast(event StatusEvent) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.clients {
+		select {
+		case ch <- event:
+		default: // skip slow clients
+		}
+	}
+}

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -35,6 +35,7 @@ type Whatsmiau struct {
 	httpClient       *http.Client
 	fileStorage      interfaces.Storage
 	handlerSemaphore chan struct{}
+	SSE              *SSEBroadcaster
 }
 
 var instance *Whatsmiau
@@ -128,6 +129,7 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 		},
 		fileStorage:      storage,
 		handlerSemaphore: make(chan struct{}, env.Env.HandlerSemaphoreSize),
+		SSE:              NewSSEBroadcaster(),
 	}
 
 	go instance.startEmitter()

--- a/server/routes/instance.go
+++ b/server/routes/instance.go
@@ -1,10 +1,6 @@
 package routes
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-
 	"github.com/labstack/echo/v4"
 	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
 	"github.com/verbeux-ai/whatsmiau/repositories/instances"
@@ -23,28 +19,7 @@ func Instance(group *echo.Group) {
 	group.DELETE("/:id", controller.Delete)
 	group.GET("/:id/status", controller.Status)
 
-	group.GET("/events/stream", func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-		c.Response().Flush()
-
-		miau := whatsmiau.Get()
-		ch := miau.SSE.Register()
-		defer miau.SSE.Unregister(ch)
-
-		for {
-			select {
-			case event := <-ch:
-				data, _ := json.Marshal(event)
-				fmt.Fprintf(c.Response(), "event: status\ndata: %s\n\n", data)
-				c.Response().Flush()
-			case <-c.Request().Context().Done():
-				return nil
-			}
-		}
-	})
+	group.GET("/events/stream", whatsmiau.Get().SSE.Handler())
 
 	// Evolution API Compatibility (partially REST)
 	group.POST("/create", controller.Create)

--- a/server/routes/instance.go
+++ b/server/routes/instance.go
@@ -1,6 +1,10 @@
 package routes
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
 	"github.com/verbeux-ai/whatsmiau/repositories/instances"
@@ -18,6 +22,29 @@ func Instance(group *echo.Group) {
 	group.POST("/:id/logout", controller.Logout)
 	group.DELETE("/:id", controller.Delete)
 	group.GET("/:id/status", controller.Status)
+
+	group.GET("/events/stream", func(c echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().Header().Set("Cache-Control", "no-cache")
+		c.Response().Header().Set("Connection", "keep-alive")
+		c.Response().WriteHeader(http.StatusOK)
+		c.Response().Flush()
+
+		miau := whatsmiau.Get()
+		ch := miau.SSE.Register()
+		defer miau.SSE.Unregister(ch)
+
+		for {
+			select {
+			case event := <-ch:
+				data, _ := json.Marshal(event)
+				fmt.Fprintf(c.Response(), "event: status\ndata: %s\n\n", data)
+				c.Response().Flush()
+			case <-c.Request().Context().Done():
+				return nil
+			}
+		}
+	})
 
 	// Evolution API Compatibility (partially REST)
 	group.POST("/create", controller.Create)

--- a/server/routes/manager.go
+++ b/server/routes/manager.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -58,4 +60,26 @@ func Manager(group *echo.Group) {
 	auth.POST("/instances/:id/logout", controller.LogoutInstance)
 	auth.DELETE("/instances/:id", controller.DeleteInstance)
 	auth.PUT("/instances/:id", controller.UpdateInstance)
+
+	auth.GET("/sse", func(c echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().Header().Set("Cache-Control", "no-cache")
+		c.Response().Header().Set("Connection", "keep-alive")
+		c.Response().WriteHeader(http.StatusOK)
+		c.Response().Flush()
+
+		ch := w.SSE.Register()
+		defer w.SSE.Unregister(ch)
+
+		for {
+			select {
+			case event := <-ch:
+				data, _ := json.Marshal(event)
+				fmt.Fprintf(c.Response(), "event: status\ndata: %s\n\n", data)
+				c.Response().Flush()
+			case <-c.Request().Context().Done():
+				return nil
+			}
+		}
+	})
 }

--- a/server/routes/manager.go
+++ b/server/routes/manager.go
@@ -1,8 +1,6 @@
 package routes
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,25 +59,5 @@ func Manager(group *echo.Group) {
 	auth.DELETE("/instances/:id", controller.DeleteInstance)
 	auth.PUT("/instances/:id", controller.UpdateInstance)
 
-	auth.GET("/sse", func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-		c.Response().Flush()
-
-		ch := w.SSE.Register()
-		defer w.SSE.Unregister(ch)
-
-		for {
-			select {
-			case event := <-ch:
-				data, _ := json.Marshal(event)
-				fmt.Fprintf(c.Response(), "event: status\ndata: %s\n\n", data)
-				c.Response().Flush()
-			case <-c.Request().Context().Done():
-				return nil
-			}
-		}
-	})
+	auth.GET("/sse", w.SSE.Handler())
 }

--- a/server/templates/instance.html
+++ b/server/templates/instance.html
@@ -3,19 +3,19 @@
 {{define "title"}}{{.Instance.ID}}{{end}}
 
 {{define "content"}}
-<div class="instance-detail">
+<div class="instance-detail" data-detail-instance="{{.Instance.ID}}">
     <a href="/manager/instances" class="back-link">&larr; Voltar para instâncias</a>
     <div class="detail-header">
         <h2>{{.Instance.ID}}</h2>
         {{template "status_badge.html" .}}
         {{if .Instance.RemoteJID}}
-            <span style="color:var(--text-light);font-size:.85rem;">{{.Instance.RemoteJID}}</span>
+            <span class="detail-jid" style="color:var(--text-light);font-size:.85rem;">{{.Instance.RemoteJID}}</span>
         {{end}}
     </div>
 
-    <div class="detail-actions">
+    <div class="detail-actions" id="detail-actions" data-status="{{.Status}}">
         {{if ne .Status "open"}}
-            <button class="btn btn-primary"
+            <button class="btn btn-primary" id="btn-connect"
                     hx-post="/manager/instances/{{.Instance.ID}}/connect"
                     hx-target="#qr-container"
                     hx-swap="innerHTML">
@@ -24,7 +24,7 @@
             </button>
         {{end}}
         {{if eq .Status "open"}}
-            <button class="btn btn-outline"
+            <button class="btn btn-outline" id="btn-logout"
                     hx-post="/manager/instances/{{.Instance.ID}}/logout"
                     hx-confirm="Isso vai desconectar o WhatsApp. Precisará escanear o QR novamente. Continuar?">
                 Desconectar

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -28,6 +28,12 @@
             form_error: 'Erro ao processar formulário',
             save_error: 'Erro ao salvar configurações'
         };
+        var statusLabels = {
+            open: 'Conectado',
+            connecting: 'Conectando',
+            'qr-code': 'QR Code',
+            closed: 'Desconectado'
+        };
         function resolveMessage(code) {
             if (!code) return '';
             if (code.indexOf(':') > -1) {
@@ -60,6 +66,75 @@
             localStorage.setItem('theme', next);
             document.getElementById('theme-icon').textContent = next === 'dark' ? '\u2600' : '\u263E';
         }
+
+        (function() {
+            var sse;
+            function connect() {
+                sse = new EventSource('/manager/sse');
+                sse.addEventListener('status', function(e) {
+                    var ev = JSON.parse(e.data);
+                    var state = ev.state === 'close' ? 'closed' : (ev.state || 'closed');
+                    var label = statusLabels[state] || 'Desconectado';
+
+                    document.querySelectorAll('[data-instance="' + ev.instance + '"]').forEach(function(badge) {
+                        badge.className = 'status-badge status-' + state;
+                        badge.textContent = label;
+                    });
+
+                    var qrContainer = document.getElementById('qr-poll-container');
+                    if (qrContainer && state === 'open' && qrContainer.getAttribute('data-instance') === ev.instance) {
+                        qrContainer.innerHTML = '<p class="qr-status qr-connected">Instância conectada!</p>';
+                        setTimeout(function(){ window.location.reload(); }, 2000);
+                    }
+
+                    var detail = document.querySelector('[data-detail-instance="' + ev.instance + '"]');
+                    if (detail) {
+                        var actions = document.getElementById('detail-actions');
+                        var btnConnect = document.getElementById('btn-connect');
+                        var btnLogout = document.getElementById('btn-logout');
+                        if (state === 'open') {
+                            if (btnConnect) btnConnect.style.display = 'none';
+                            if (!btnLogout && actions) {
+                                var btn = document.createElement('button');
+                                btn.id = 'btn-logout';
+                                btn.className = 'btn btn-outline';
+                                btn.setAttribute('hx-post', '/manager/instances/' + ev.instance + '/logout');
+                                btn.setAttribute('hx-confirm', 'Isso vai desconectar o WhatsApp. Precisará escanear o QR novamente. Continuar?');
+                                btn.innerHTML = 'Desconectar <span class="htmx-indicator"></span>';
+                                actions.insertBefore(btn, actions.firstChild);
+                                htmx.process(btn);
+                            } else if (btnLogout) {
+                                btnLogout.style.display = '';
+                            }
+                        } else if (state === 'closed') {
+                            if (btnLogout) btnLogout.style.display = 'none';
+                            if (!btnConnect && actions) {
+                                var btn = document.createElement('button');
+                                btn.id = 'btn-connect';
+                                btn.className = 'btn btn-primary';
+                                btn.setAttribute('hx-post', '/manager/instances/' + ev.instance + '/connect');
+                                btn.setAttribute('hx-target', '#qr-container');
+                                btn.setAttribute('hx-swap', 'innerHTML');
+                                btn.innerHTML = 'Conectar <span class="htmx-indicator"></span>';
+                                actions.insertBefore(btn, actions.firstChild);
+                                htmx.process(btn);
+                            } else if (btnConnect) {
+                                btnConnect.style.display = '';
+                            }
+                            var qr = document.getElementById('qr-container');
+                            if (qr) qr.innerHTML = '';
+                        }
+                    }
+                });
+                sse.onerror = function() {
+                    sse.close();
+                    setTimeout(connect, 5000);
+                };
+            }
+            document.addEventListener('DOMContentLoaded', function() {
+                if (document.querySelector('.header-logout')) connect();
+            });
+        })();
     </script>
 </head>
 <body>

--- a/server/templates/partials/instances_grid.html
+++ b/server/templates/partials/instances_grid.html
@@ -5,7 +5,9 @@
         <a href="/manager/instances/{{.ID}}" class="instance-card">
             <div class="card-header">
                 <span class="card-id">{{.ID}}</span>
-                {{template "status_badge_static.html" .Status}}
+                <span class="status-badge status-{{.Status}}" data-instance="{{.ID}}">
+                    {{if eq .Status "open"}}Conectado{{else if eq .Status "connecting"}}Conectando{{else if eq .Status "qr-code"}}QR Code{{else}}Desconectado{{end}}
+                </span>
             </div>
             <span class="card-jid">{{if .RemoteJID}}{{.RemoteJID}}{{else}}Não conectado{{end}}</span>
         </a>

--- a/server/templates/partials/qrcode.html
+++ b/server/templates/partials/qrcode.html
@@ -5,10 +5,7 @@
     </div>
     <script>setTimeout(function(){ window.location.reload(); }, 2000);</script>
 {{else if .QRBase64}}
-    <div class="qr-container" id="qr-poll-container"
-         hx-get="/manager/instances/{{.ID}}/qr-poll"
-         hx-trigger="every 3s"
-         hx-swap="outerHTML">
+    <div class="qr-container" id="qr-poll-container" data-instance="{{.ID}}">
         <img src="data:image/png;base64,{{.QRBase64}}" alt="QR Code" width="256" height="256">
         <p class="qr-status">Escaneie o QR code com o WhatsApp</p>
     </div>
@@ -16,9 +13,6 @@
         setTimeout(function(){
             var c = document.getElementById('qr-poll-container');
             if (c) {
-                c.removeAttribute('hx-get');
-                c.removeAttribute('hx-trigger');
-                htmx.process(c);
                 c.innerHTML = '<p class="qr-status qr-expired">QR code expirado</p>' +
                     '<button class="btn btn-primary" style="margin-top:.75rem;" ' +
                     'hx-post="/manager/instances/{{.ID}}/connect" ' +

--- a/server/templates/partials/status_badge.html
+++ b/server/templates/partials/status_badge.html
@@ -3,9 +3,3 @@
     {{if eq .Status "open"}}Conectado{{else if eq .Status "connecting"}}Conectando{{else if eq .Status "qr-code"}}QR Code{{else}}Desconectado{{end}}
 </span>
 {{end}}
-
-{{define "status_badge_static.html"}}
-<span class="status-badge status-{{.}}">
-    {{if eq . "open"}}Conectado{{else if eq . "connecting"}}Conectando{{else if eq . "qr-code"}}QR Code{{else}}Desconectado{{end}}
-</span>
-{{end}}

--- a/server/templates/partials/status_badge.html
+++ b/server/templates/partials/status_badge.html
@@ -1,8 +1,5 @@
 {{define "status_badge.html"}}
-<span class="status-badge status-{{.Status}}"
-      hx-get="/manager/instances/{{.ID}}/status"
-      hx-trigger="every 10s"
-      hx-swap="outerHTML">
+<span class="status-badge status-{{.Status}}" data-instance="{{.ID}}">
     {{if eq .Status "open"}}Conectado{{else if eq .Status "connecting"}}Conectando{{else if eq .Status "qr-code"}}QR Code{{else}}Desconectado{{end}}
 </span>
 {{end}}


### PR DESCRIPTION
## Atualização de status em tempo real via SSE

### Motivação

O dashboard do manager usava **polling HTTP** para manter o status das instâncias atualizado — a cada 10 segundos na badge de status e a cada 3 segundos no QR code. Isso gerava requisições desnecessárias ao servidor mesmo quando nada mudava, desperdiçando recursos tanto no backend quanto no browser, e ainda assim o feedback para o usuário tinha um atraso perceptível (até 10s para refletir uma conexão ou desconexão).

### O que mudou

O polling foi substituído por **Server-Sent Events (SSE)**. Agora o servidor notifica o browser instantaneamente quando uma instância conecta, desconecta ou falha — sem requisições extras e sem delay.

- Novo broadcaster SSE no core da API que escuta eventos do WhatsApp (connect, disconnect, failure) e repassa para todos os clients conectados
- Dois endpoints SSE: um na API pública (`/v1/instance/events/stream`) e outro interno do manager (`/manager/sse`)
- O frontend mantém uma conexão SSE aberta e atualiza badges de status, QR code e botões de ação em tempo real, sem recarregar a página
- Removidos todos os `hx-trigger="every Xs"` e `hx-get` de polling dos templates