### PR TITLE
feat: emit history sync messages via webhook

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -455,15 +455,28 @@ func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance,
 		}
 	}
 
-	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado)
+	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado).
+	// Executa em goroutine para não bloquear o event loop: em contas antigas
+	// o HistorySync pode trazer dezenas de milhares de mensagens.
 	if eventMap["MESSAGES_UPSERT"] {
-		s.emitHistoryMessages(id, instance, e)
+		go s.emitHistoryMessages(id, instance, e)
 	}
 }
 
 func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e *events.HistorySync) {
 	ctx, c := context.WithTimeout(context.Background(), time.Minute*5)
 	defer c()
+
+	// Carrega o client uma vez — evita map lookup por mensagem.
+	client, ok := s.clients.Load(id)
+	if !ok {
+		return
+	}
+
+	var ownJid string
+	if own := client.Store.ID; own != nil {
+		ownJid = own.ToNonAD().String()
+	}
 
 	total := 0
 	for _, conv := range e.Data.GetConversations() {
@@ -478,6 +491,9 @@ func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e 
 		if err != nil {
 			continue
 		}
+
+		// JID/LID é constante dentro da conversa — resolve uma vez só.
+		jid, lid := s.GetJidLid(ctx, id, chatJid)
 
 		for _, histMsg := range conv.GetMessages() {
 			webMsgInfo := histMsg.GetMessage()
@@ -501,15 +517,11 @@ func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e 
 				continue
 			}
 
-			jid, lid := s.GetJidLid(ctx, id, chatJid)
-
 			// Sender (pode ser o próprio chat em 1-1, ou Participant em grupos)
 			senderJid := jid
 			if key.GetFromMe() {
-				if client, ok := s.clients.Load(id); ok {
-					if own := client.Store.ID; own != nil {
-						senderJid = own.ToNonAD().String()
-					}
+				if ownJid != "" {
+					senderJid = ownJid
 				}
 			} else if p := key.GetParticipant(); p != "" {
 				if pJid, perr := types.ParseJID(p); perr == nil {

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -441,23 +441,134 @@ func (s *Whatsmiau) handlePictureEvent(id string, instance *models.Instance, e *
 }
 
 func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance, e *events.HistorySync, eventMap map[string]bool) {
-	if !eventMap["CONTACTS_UPSERT"] {
-		return
+	// Emitir contatos (comportamento original)
+	if eventMap["CONTACTS_UPSERT"] {
+		data := s.convertContactHistorySync(id, e.Data.GetPushnames(), e.Data.Conversations)
+		if data != nil {
+			wookData := &WookEvent[WookContactUpsertData]{
+				Instance: instance.ID,
+				Data:     &data,
+				DateTime: time.Now(),
+				Event:    WookContactsUpsert,
+			}
+			s.emit(wookData, instance.Webhook.Url)
+		}
 	}
 
-	data := s.convertContactHistorySync(id, e.Data.GetPushnames(), e.Data.Conversations)
-	if data == nil {
-		return
+	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado)
+	if eventMap["MESSAGES_UPSERT"] {
+		s.emitHistoryMessages(id, instance, e)
+	}
+}
+
+func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e *events.HistorySync) {
+	ctx, c := context.WithTimeout(context.Background(), time.Minute*5)
+	defer c()
+
+	total := 0
+	for _, conv := range e.Data.GetConversations() {
+		// Ignorar grupos se configurado
+		if instance.GroupsIgnore {
+			if strings.Contains(conv.GetID(), "@g.us") {
+				continue
+			}
+		}
+
+		chatJid, err := types.ParseJID(conv.GetID())
+		if err != nil {
+			continue
+		}
+
+		for _, histMsg := range conv.GetMessages() {
+			webMsgInfo := histMsg.GetMessage()
+			if webMsgInfo == nil || webMsgInfo.GetMessage() == nil {
+				continue
+			}
+
+			key := webMsgInfo.GetKey()
+			if key == nil {
+				continue
+			}
+
+			msg := webMsgInfo.GetMessage()
+			// Ignorar mensagens de protocolo (criptografia, etc)
+			if msg.GetProtocolMessage() != nil {
+				continue
+			}
+
+			messageType, raw, ci := s.parseWAMessage(msg)
+			if raw == nil {
+				continue
+			}
+
+			jid, lid := s.GetJidLid(ctx, id, chatJid)
+
+			// Sender (pode ser o próprio chat em 1-1, ou Participant em grupos)
+			senderJid := jid
+			if key.GetFromMe() {
+				if client, ok := s.clients.Load(id); ok {
+					if own := client.Store.ID; own != nil {
+						senderJid = own.ToNonAD().String()
+					}
+				}
+			} else if p := key.GetParticipant(); p != "" {
+				if pJid, perr := types.ParseJID(p); perr == nil {
+					senderJid, _ = s.GetJidLid(ctx, id, pJid)
+				}
+			}
+
+			wookKey := &WookKey{
+				RemoteJid:   jid,
+				RemoteLid:   lid,
+				FromMe:      key.GetFromMe(),
+				Id:          key.GetID(),
+				Participant: senderJid,
+			}
+
+			status := "received"
+			if key.GetFromMe() {
+				status = "sent"
+			}
+
+			ts := time.Unix(int64(webMsgInfo.GetMessageTimestamp()), 0)
+
+			var messageContext WookMessageContextInfo
+			if ci != nil {
+				messageContext.StanzaId = ci.GetStanzaID()
+				messageContext.Participant = ci.GetParticipant()
+				if qm := ci.GetQuotedMessage(); qm != nil {
+					_, qmRaw, _ := s.parseWAMessage(qm)
+					messageContext.QuotedMessage = qmRaw
+				}
+			}
+
+			messageData := &WookMessageData{
+				Key:              wookKey,
+				PushName:         strings.TrimSpace(webMsgInfo.GetPushName()),
+				Status:           status,
+				Message:          raw,
+				ContextInfo:      &messageContext,
+				MessageType:      messageType,
+				MessageTimestamp: int(ts.Unix()),
+				InstanceId:       instance.ID,
+				Source:           "whatsapp-history",
+			}
+
+			wookMessage := &WookEvent[WookMessageData]{
+				Instance: instance.ID,
+				Data:     messageData,
+				DateTime: ts,
+				Event:    WookMessagesUpsert,
+			}
+
+			s.emit(wookMessage, instance.Webhook.Url)
+			total++
+		}
 	}
 
-	wookData := &WookEvent[WookContactUpsertData]{
-		Instance: instance.ID,
-		Data:     &data,
-		DateTime: time.Now(),
-		Event:    WookContactsUpsert,
+	if total > 0 {
+		zap.L().Info("history messages emitted", zap.String("instance", instance.ID), zap.Int("total", total))
 	}
-
-	s.emit(wookData, instance.Webhook.Url)
 }
 
 func (s *Whatsmiau) handleGroupInfoEvent(id string, instance *models.Instance, e *events.GroupInfo, eventMap map[string]bool) {


### PR DESCRIPTION
## Summary

- Historical messages received in the `HistorySync` event are now forwarded to the webhook as `MESSAGES_UPSERT` events (source: `whatsapp-history`), respecting the instance's `eventMap` and `GroupsIgnore` flag.
- Previous behavior for `CONTACTS_UPSERT` is preserved — this only **adds** message emission when `MESSAGES_UPSERT` is subscribed.

## Motivation

When an instance reconnects, WhatsApp replays recent conversations via `HistorySync`. Previously, only contacts were emitted; messages were silently dropped. Consumers that want to mirror the full message archive had to call `chat.findMessages` per chat as a workaround.

With this change, a reconnect alone is enough to backfill the webhook consumer. In our own test against ~6 months of history, a single reconnect emitted **~24k messages** that were correctly ingested downstream with zero errors.

## Implementation notes

- Opt-in: only fires when `eventMap["MESSAGES_UPSERT"]` is true; existing subscribers that don't want the replay are unaffected.
- Runs in its own goroutine so the event handler semaphore is not blocked for large histories.
- Protocol messages (E2E housekeeping / disappearing config) are skipped.
- Client is loaded once; own JID is cached once.
- Conversation JID/LID is resolved once per conversation (not per message).
- Sender resolution:
  - `fromMe` → cached own JID
  - groups → `key.GetParticipant()` when present
- Quoted messages are decoded through `parseWAMessage` for completeness.
- Groups are filtered when `instance.GroupsIgnore` is set, matching the rest of the codebase.
- Payload shape is identical to live `MESSAGES_UPSERT` — only `Source` differs (`"whatsapp-history"`), so downstream handlers can optionally distinguish replay from live.

## Test plan

- [x] Reconnect instance with `MESSAGES_UPSERT` subscribed → historical messages emitted; log line `history messages emitted ... total: N` confirms count.
- [x] Reconnect with only `CONTACTS_UPSERT` subscribed → no behavior change (historical messages NOT emitted).
- [x] `GroupsIgnore=true` → group chats from history skipped.
- [ ] Maintainers: please confirm payload matches expectations on your stack.

---

Opened from fork: https://github.com/mendesalexandre/whatsmiau/tree/feat/emit-history-messages