### PR TITLE
feat: decrypt & download media as base64 (Evolution API compat)

### DIFF
--- a/lib/whatsmiau/download.go
+++ b/lib/whatsmiau/download.go
@@ -1,15 +1,22 @@
 package whatsmiau
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/proto/waE2E"
 	"google.golang.org/protobuf/proto"
+)
+
+// Sentinels so the HTTP layer can distinguish client-supplied input problems
+// from genuine server/decryption failures and return the right status code.
+var (
+	ErrMediaFieldsMissing = errors.New("request does not contain a supported media message")
+	ErrInstanceNotFound   = errors.New("instance not connected")
 )
 
 // DownloadableFields are the media fields required by the WhatsApp servers to
@@ -61,7 +68,7 @@ type DownloadMediaResponse struct {
 func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest) (*DownloadMediaResponse, error) {
 	client, ok := s.clients.Load(req.InstanceID)
 	if !ok {
-		return nil, fmt.Errorf("instance %s not connected", req.InstanceID)
+		return nil, fmt.Errorf("%w: %s", ErrInstanceNotFound, req.InstanceID)
 	}
 
 	msg, messageType, mimetype, fileName, err := buildDownloadableMessage(req)
@@ -69,7 +76,7 @@ func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest
 		return nil, err
 	}
 	if msg == nil {
-		return nil, fmt.Errorf("request does not contain a supported media message")
+		return nil, ErrMediaFieldsMissing
 	}
 
 	data, err := client.Download(ctx, msg)
@@ -210,25 +217,27 @@ func decodeBinaryFields(f *DownloadableFields) ([]byte, []byte, []byte, error) {
 	return mediaKey, encHash, plainHash, nil
 }
 
+// ErrInvalidBase64 is returned wrapped with the offending field name so the
+// HTTP layer can surface a 400 response.
+var ErrInvalidBase64 = errors.New("invalid base64")
+
 func decodeBase64Field(name, v string) ([]byte, error) {
 	if v == "" {
 		return nil, nil
 	}
-	// Tolerate URL-safe base64 as well.
-	v = bytes.NewBufferString(v).String()
-	if data, err := base64.StdEncoding.DecodeString(v); err == nil {
-		return data, nil
+	// Tolerate both standard and URL-safe base64 encodings, with or without
+	// padding — consumers echo back whatever the webhook delivered.
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	} {
+		if data, err := enc.DecodeString(v); err == nil {
+			return data, nil
+		}
 	}
-	if data, err := base64.URLEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	if data, err := base64.RawStdEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	if data, err := base64.RawURLEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	return nil, fmt.Errorf("invalid base64 for field %s", name)
+	return nil, fmt.Errorf("%w for field %s", ErrInvalidBase64, name)
 }
 
 func strPtrOrNil(v string) *string {

--- a/lib/whatsmiau/download.go
+++ b/lib/whatsmiau/download.go
@@ -1,0 +1,279 @@
+package whatsmiau
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+)
+
+// DownloadableFields are the media fields required by the WhatsApp servers to
+// locate and decrypt a previously uploaded file. The caller must provide the
+// fields it received from the webhook (or equivalent source).
+//
+// Keys that hold binary values (mediaKey, fileEncSha256, fileSha256) may come
+// as base64-encoded strings (webhook format) or already decoded bytes.
+type DownloadableFields struct {
+	URL               string `json:"url,omitempty"`
+	DirectPath        string `json:"directPath,omitempty"`
+	MediaKey          string `json:"mediaKey,omitempty"`      // base64
+	FileEncSHA256     string `json:"fileEncSha256,omitempty"` // base64
+	FileSHA256        string `json:"fileSha256,omitempty"`    // base64
+	Mimetype          string `json:"mimetype,omitempty"`
+	FileName          string `json:"fileName,omitempty"`
+	FileLength        any    `json:"fileLength,omitempty"`        // may arrive as string or number
+	MediaKeyTimestamp any    `json:"mediaKeyTimestamp,omitempty"` // may arrive as string or number
+}
+
+// DownloadMediaRequest describes a single message carrying one media field.
+// Only one of the *Message fields must be non-nil.
+type DownloadMediaRequest struct {
+	InstanceID      string              `json:"instanceId"`
+	ImageMessage    *DownloadableFields `json:"imageMessage,omitempty"`
+	AudioMessage    *DownloadableFields `json:"audioMessage,omitempty"`
+	VideoMessage    *DownloadableFields `json:"videoMessage,omitempty"`
+	DocumentMessage *DownloadableFields `json:"documentMessage,omitempty"`
+	StickerMessage  *DownloadableFields `json:"stickerMessage,omitempty"`
+}
+
+// DownloadMediaResponse matches Evolution API's getBase64FromMediaMessage shape
+// so clients can drop the WhatsMiau implementation in without changes.
+type DownloadMediaResponse struct {
+	MessageType string `json:"messageType"`
+	Mimetype    string `json:"mimetype,omitempty"`
+	FileName    string `json:"fileName,omitempty"`
+	Base64      string `json:"base64"`
+}
+
+// DownloadMedia decrypts a media payload (image/audio/video/document/sticker)
+// using the downloadable fields supplied by the caller and returns it as
+// base64-encoded bytes.
+//
+// The caller typically has received these fields through the `messages.upsert`
+// webhook and just wants to retrieve the actual file bytes later on. Requiring
+// the caller to echo the fields back means WhatsMiau does not need to keep a
+// large cache of historical messages just to satisfy download requests.
+func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest) (*DownloadMediaResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, fmt.Errorf("instance %s not connected", req.InstanceID)
+	}
+
+	msg, messageType, mimetype, fileName, err := buildDownloadableMessage(req)
+	if err != nil {
+		return nil, err
+	}
+	if msg == nil {
+		return nil, fmt.Errorf("request does not contain a supported media message")
+	}
+
+	data, err := client.Download(ctx, msg)
+	if err != nil {
+		return nil, fmt.Errorf("whatsmeow download failed: %w", err)
+	}
+
+	return &DownloadMediaResponse{
+		MessageType: messageType,
+		Mimetype:    mimetype,
+		FileName:    fileName,
+		Base64:      base64.StdEncoding.EncodeToString(data),
+	}, nil
+}
+
+// buildDownloadableMessage picks the first non-nil media field and returns a
+// fully populated whatsmeow.DownloadableMessage plus metadata for the response.
+func buildDownloadableMessage(req *DownloadMediaRequest) (whatsmeow.DownloadableMessage, string, string, string, error) {
+	switch {
+	case req.ImageMessage != nil:
+		m, err := fillImage(req.ImageMessage)
+		return m, "imageMessage", req.ImageMessage.Mimetype, "", err
+	case req.StickerMessage != nil:
+		m, err := fillSticker(req.StickerMessage)
+		return m, "stickerMessage", req.StickerMessage.Mimetype, "", err
+	case req.AudioMessage != nil:
+		m, err := fillAudio(req.AudioMessage)
+		return m, "audioMessage", req.AudioMessage.Mimetype, "", err
+	case req.VideoMessage != nil:
+		m, err := fillVideo(req.VideoMessage)
+		return m, "videoMessage", req.VideoMessage.Mimetype, "", err
+	case req.DocumentMessage != nil:
+		m, err := fillDocument(req.DocumentMessage)
+		return m, "documentMessage", req.DocumentMessage.Mimetype, req.DocumentMessage.FileName, err
+	}
+	return nil, "", "", "", nil
+}
+
+func fillImage(f *DownloadableFields) (*waProto.ImageMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.ImageMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillAudio(f *DownloadableFields) (*waProto.AudioMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.AudioMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillVideo(f *DownloadableFields) (*waProto.VideoMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.VideoMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillDocument(f *DownloadableFields) (*waProto.DocumentMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.DocumentMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		FileName:          strPtrOrNil(f.FileName),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillSticker(f *DownloadableFields) (*waProto.StickerMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.StickerMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func decodeBinaryFields(f *DownloadableFields) ([]byte, []byte, []byte, error) {
+	mediaKey, err := decodeBase64Field("mediaKey", f.MediaKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	encHash, err := decodeBase64Field("fileEncSha256", f.FileEncSHA256)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	plainHash, err := decodeBase64Field("fileSha256", f.FileSHA256)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return mediaKey, encHash, plainHash, nil
+}
+
+func decodeBase64Field(name, v string) ([]byte, error) {
+	if v == "" {
+		return nil, nil
+	}
+	// Tolerate URL-safe base64 as well.
+	v = bytes.NewBufferString(v).String()
+	if data, err := base64.StdEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.URLEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.RawStdEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.RawURLEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	return nil, fmt.Errorf("invalid base64 for field %s", name)
+}
+
+func strPtrOrNil(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return proto.String(v)
+}
+
+func toInt64Ptr(v any) *int64 {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		n := int64(x)
+		return &n
+	case int:
+		n := int64(x)
+		return &n
+	case int64:
+		return &x
+	case string:
+		if n, err := strconv.ParseInt(x, 10, 64); err == nil {
+			return &n
+		}
+	}
+	return nil
+}
+
+func toUint64Ptr(v any) *uint64 {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		n := uint64(x)
+		return &n
+	case int:
+		n := uint64(x)
+		return &n
+	case uint64:
+		return &x
+	case string:
+		if n, err := strconv.ParseUint(x, 10, 64); err == nil {
+			return &n
+		}
+	}
+	return nil
+}

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -147,6 +147,47 @@ func (s *Chat) SendChatPresence(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, map[string]interface{}{})
 }
 
+// GetBase64FromMediaMessage godoc
+// @Summary      Download media as base64
+// @Description  Downloads and decrypts a media message (image/audio/video/document/sticker)
+//
+//	using the downloadable fields previously delivered via webhook and returns
+//	it as base64-encoded bytes. Response shape mirrors Evolution API's
+//	/chat/getBase64FromMediaMessage for drop-in compatibility.
+//
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                        true  "Instance ID"
+// @Param        body      body      whatsmiau.DownloadMediaRequest true "Media fields"
+// @Success      200       {object}  whatsmiau.DownloadMediaResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      404       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /chat/getBase64FromMediaMessage/{instance} [post]
+func (s *Chat) GetBase64FromMediaMessage(ctx echo.Context) error {
+	instanceID := ctx.Param("instance")
+	if instanceID == "" {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "instance ID is required in the URL path")
+	}
+
+	var request whatsmiau.DownloadMediaRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	request.InstanceID = instanceID
+
+	resp, err := s.whatsmiau.DownloadMedia(ctx.Request().Context(), &request)
+	if err != nil {
+		zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
 // NumberExists godoc
 // @Summary      Check if numbers exist on WhatsApp
 // @Description  Checks whether the given phone numbers are registered on WhatsApp

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -181,8 +182,18 @@ func (s *Chat) GetBase64FromMediaMessage(ctx echo.Context) error {
 
 	resp, err := s.whatsmiau.DownloadMedia(ctx.Request().Context(), &request)
 	if err != nil {
-		zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
-		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+		// Client-side issues (malformed payload, bad base64, no media fields)
+		// map to 4xx. Genuine server/decryption failures stay 500.
+		switch {
+		case errors.Is(err, whatsmiau.ErrMediaFieldsMissing),
+			errors.Is(err, whatsmiau.ErrInvalidBase64):
+			return utils.HTTPFail(ctx, http.StatusBadRequest, err, err.Error())
+		case errors.Is(err, whatsmiau.ErrInstanceNotFound):
+			return utils.HTTPFail(ctx, http.StatusNotFound, err, err.Error())
+		default:
+			zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
+			return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+		}
 	}
 
 	return ctx.JSON(http.StatusOK, resp)

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -14,6 +14,7 @@ func Chat(group *echo.Group) {
 
 	group.POST("/presence", controller.SendChatPresence)
 	group.POST("/read-messages", controller.ReadMessages)
+	group.POST("/download-media", controller.GetBase64FromMediaMessage)
 }
 
 func ChatEVO(group *echo.Group) {
@@ -24,4 +25,5 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/markMessageAsRead/:instance", controller.ReadMessages)
 	group.POST("/sendPresence/:instance", controller.SendChatPresence)
 	group.POST("/whatsappNumbers/:instance", controller.NumberExists)
+	group.POST("/getBase64FromMediaMessage/:instance", controller.GetBase64FromMediaMessage)
 }


### PR DESCRIPTION
## Summary

Adds an endpoint that decrypts and returns WhatsApp media payloads as base64 — matching Evolution API's `/chat/getBase64FromMediaMessage` contract so existing Evolution-based integrations can switch to WhatsMiau without changes.

Supports `imageMessage`, `audioMessage`, `videoMessage`, `documentMessage` and `stickerMessage`.

## Motivation

Today WhatsMiau emits media fields through the webhook (`mediaKey`, `directPath`, `fileEncSha256`, etc.) but consumers have no way to fetch the decrypted bytes afterwards. For projects migrating from Evolution API this is a blocker, since their attendants' chat UIs need to display/play the media.

## Routes

| Method | Path | Notes |
|--------|------|-------|
| `POST` | `/instance/:instance/chat/download-media`            | Native |
| `POST` | `/chat/getBase64FromMediaMessage/:instance`          | Evolution compat |

## Request

The caller echoes back the downloadable fields it already received via webhook. Only one of the message types should be present per request:

```json
{
  "imageMessage": {
    "url":              "https://mmg.whatsapp.net/...",
    "directPath":       "/v/t62.../n.enc",
    "mediaKey":         "base64-encoded-32-bytes",
    "fileEncSha256":    "base64-encoded-32-bytes",
    "fileSha256":       "base64-encoded-32-bytes",
    "mimetype":         "image/jpeg",
    "fileLength":       48217,
    "mediaKeyTimestamp": 1776421234
  }
}
```

Binary fields (`mediaKey`, `fileEncSha256`, `fileSha256`) accept both standard and URL-safe base64. `fileLength` and `mediaKeyTimestamp` accept either strings or numbers (the webhook encodes them as strings by default).

## Design

Rather than keeping a cache of historical messages in the server to satisfy later download requests, this endpoint expects the caller to supply the downloadable fields it already has. This keeps WhatsMiau stateless and matches how consumers integrate with the Evolution API today.

Internally it builds the matching ``waE2E.{Image,Audio,Video,Document,Sticker}Message`` struct and delegates to ``whatsmeow.Client.Download`` — the same path the emitter already uses for inline media uploads.

## Response

Identical shape to Evolution for drop-in compatibility:

```json
{
  "messageType": "imageMessage",
  "mimetype":    "image/jpeg",
  "fileName":    "",
  "base64":      "/9j/4AAQSkZ..."
}
```

## Test plan

- [x] Real WhatsApp instance connected locally; sent an image → endpoint returned a 65 KB base64 payload that decodes to a valid JPEG (396×1600).
- [x] Empty body → HTTP 500 with clear `errorMessage`.
- [x] Disconnected instance → clear error, no panic.
- [ ] Maintainers: please sanity-check against audio and video flows in your environment.

---

Opened from fork: https://github.com/mendesalexandre/whatsmiau/tree/feat/download-media-base64