### PR TITLE
feat: add fetchProfilePictureUrl endpoint (Evolution compat)

### DIFF
--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -1,6 +1,8 @@
 package whatsmiau
 
 import (
+	"errors"
+	"strings"
 	"time"
 
 	"go.mau.fi/whatsmeow"
@@ -8,6 +10,10 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
+
+// ErrEmptyNumber is returned when FetchProfilePictureUrl is called with a
+// blank number. Exported so the controller can map it to HTTP 400.
+var ErrEmptyNumber = errors.New("number is empty")
 
 type ReadMessageRequest struct {
 	MessageIDs []string   `json:"message_ids"`
@@ -84,6 +90,74 @@ func (s *Whatsmiau) NumberExists(ctx context.Context, data *NumberExistsRequest)
 	}
 
 	return results, nil
+}
+
+type FetchProfilePictureUrlRequest struct {
+	InstanceID string `json:"instance_id"`
+	Number     string `json:"number"`
+}
+
+type FetchProfilePictureUrlResponse struct {
+	Wuid              string `json:"wuid"`
+	ProfilePictureURL string `json:"profilePictureUrl"`
+}
+
+// FetchProfilePictureUrl resolves a raw phone number to a WhatsApp JID and
+// returns the full-resolution profile picture URL. Mirrors Evolution API's
+// POST /chat/fetchProfilePictureUrl/{instance}.
+func (s *Whatsmiau) FetchProfilePictureUrl(ctx context.Context, data *FetchProfilePictureUrlRequest) (*FetchProfilePictureUrlResponse, error) {
+	client, ok := s.clients.Load(data.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	number := strings.TrimSpace(data.Number)
+	if number == "" {
+		return nil, ErrEmptyNumber
+	}
+
+	// Accept already-JID inputs ("5511...@s.whatsapp.net", group JIDs, etc).
+	var jid types.JID
+	if strings.Contains(number, "@") {
+		parsed, err := types.ParseJID(number)
+		if err != nil {
+			return nil, err
+		}
+		jid = parsed
+	} else {
+		digits := strings.Map(func(r rune) rune {
+			if r >= '0' && r <= '9' {
+				return r
+			}
+			return -1
+		}, number)
+		if digits == "" {
+			return nil, ErrEmptyNumber
+		}
+		jid = types.NewJID(digits, types.DefaultUserServer)
+		// Tries Brazilian 9th-digit fallback when applicable.
+		jid = s.resolveJID(ctx, client, jid)
+	}
+
+	pic, err := client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
+		Preview:     false,
+		IsCommunity: false,
+	})
+	if err != nil {
+		// whatsmeow returns ErrProfilePictureUnauthorized / Not404d via error.
+		// Keep compat with Evolution: return empty URL instead of 500 when the
+		// profile exists but the picture isn't visible.
+		zap.L().Debug("FetchProfilePictureUrl: pic lookup failed",
+			zap.String("instance", data.InstanceID),
+			zap.String("jid", jid.String()),
+			zap.Error(err))
+	}
+
+	resp := &FetchProfilePictureUrlResponse{Wuid: jid.String()}
+	if pic != nil {
+		resp.ProfilePictureURL = pic.URL
+	}
+	return resp, nil
 }
 
 func (s *Whatsmiau) resolveJID(ctx context.Context, client *whatsmeow.Client, jid types.JID) types.JID {

--- a/lib/whatsmiau/download.go
+++ b/lib/whatsmiau/download.go
@@ -1,15 +1,22 @@
 package whatsmiau
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/proto/waE2E"
 	"google.golang.org/protobuf/proto"
+)
+
+// Sentinels so the HTTP layer can distinguish client-supplied input problems
+// from genuine server/decryption failures and return the right status code.
+var (
+	ErrMediaFieldsMissing = errors.New("request does not contain a supported media message")
+	ErrInstanceNotFound   = errors.New("instance not connected")
 )
 
 // DownloadableFields are the media fields required by the WhatsApp servers to
@@ -61,7 +68,7 @@ type DownloadMediaResponse struct {
 func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest) (*DownloadMediaResponse, error) {
 	client, ok := s.clients.Load(req.InstanceID)
 	if !ok {
-		return nil, fmt.Errorf("instance %s not connected", req.InstanceID)
+		return nil, fmt.Errorf("%w: %s", ErrInstanceNotFound, req.InstanceID)
 	}
 
 	msg, messageType, mimetype, fileName, err := buildDownloadableMessage(req)
@@ -69,7 +76,7 @@ func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest
 		return nil, err
 	}
 	if msg == nil {
-		return nil, fmt.Errorf("request does not contain a supported media message")
+		return nil, ErrMediaFieldsMissing
 	}
 
 	data, err := client.Download(ctx, msg)
@@ -210,25 +217,27 @@ func decodeBinaryFields(f *DownloadableFields) ([]byte, []byte, []byte, error) {
 	return mediaKey, encHash, plainHash, nil
 }
 
+// ErrInvalidBase64 is returned wrapped with the offending field name so the
+// HTTP layer can surface a 400 response.
+var ErrInvalidBase64 = errors.New("invalid base64")
+
 func decodeBase64Field(name, v string) ([]byte, error) {
 	if v == "" {
 		return nil, nil
 	}
-	// Tolerate URL-safe base64 as well.
-	v = bytes.NewBufferString(v).String()
-	if data, err := base64.StdEncoding.DecodeString(v); err == nil {
-		return data, nil
+	// Tolerate both standard and URL-safe base64 encodings, with or without
+	// padding — consumers echo back whatever the webhook delivered.
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	} {
+		if data, err := enc.DecodeString(v); err == nil {
+			return data, nil
+		}
 	}
-	if data, err := base64.URLEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	if data, err := base64.RawStdEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	if data, err := base64.RawURLEncoding.DecodeString(v); err == nil {
-		return data, nil
-	}
-	return nil, fmt.Errorf("invalid base64 for field %s", name)
+	return nil, fmt.Errorf("%w for field %s", ErrInvalidBase64, name)
 }
 
 func strPtrOrNil(v string) *string {

--- a/lib/whatsmiau/download.go
+++ b/lib/whatsmiau/download.go
@@ -1,0 +1,279 @@
+package whatsmiau
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+)
+
+// DownloadableFields are the media fields required by the WhatsApp servers to
+// locate and decrypt a previously uploaded file. The caller must provide the
+// fields it received from the webhook (or equivalent source).
+//
+// Keys that hold binary values (mediaKey, fileEncSha256, fileSha256) may come
+// as base64-encoded strings (webhook format) or already decoded bytes.
+type DownloadableFields struct {
+	URL               string `json:"url,omitempty"`
+	DirectPath        string `json:"directPath,omitempty"`
+	MediaKey          string `json:"mediaKey,omitempty"`      // base64
+	FileEncSHA256     string `json:"fileEncSha256,omitempty"` // base64
+	FileSHA256        string `json:"fileSha256,omitempty"`    // base64
+	Mimetype          string `json:"mimetype,omitempty"`
+	FileName          string `json:"fileName,omitempty"`
+	FileLength        any    `json:"fileLength,omitempty"`        // may arrive as string or number
+	MediaKeyTimestamp any    `json:"mediaKeyTimestamp,omitempty"` // may arrive as string or number
+}
+
+// DownloadMediaRequest describes a single message carrying one media field.
+// Only one of the *Message fields must be non-nil.
+type DownloadMediaRequest struct {
+	InstanceID      string              `json:"instanceId"`
+	ImageMessage    *DownloadableFields `json:"imageMessage,omitempty"`
+	AudioMessage    *DownloadableFields `json:"audioMessage,omitempty"`
+	VideoMessage    *DownloadableFields `json:"videoMessage,omitempty"`
+	DocumentMessage *DownloadableFields `json:"documentMessage,omitempty"`
+	StickerMessage  *DownloadableFields `json:"stickerMessage,omitempty"`
+}
+
+// DownloadMediaResponse matches Evolution API's getBase64FromMediaMessage shape
+// so clients can drop the WhatsMiau implementation in without changes.
+type DownloadMediaResponse struct {
+	MessageType string `json:"messageType"`
+	Mimetype    string `json:"mimetype,omitempty"`
+	FileName    string `json:"fileName,omitempty"`
+	Base64      string `json:"base64"`
+}
+
+// DownloadMedia decrypts a media payload (image/audio/video/document/sticker)
+// using the downloadable fields supplied by the caller and returns it as
+// base64-encoded bytes.
+//
+// The caller typically has received these fields through the `messages.upsert`
+// webhook and just wants to retrieve the actual file bytes later on. Requiring
+// the caller to echo the fields back means WhatsMiau does not need to keep a
+// large cache of historical messages just to satisfy download requests.
+func (s *Whatsmiau) DownloadMedia(ctx context.Context, req *DownloadMediaRequest) (*DownloadMediaResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, fmt.Errorf("instance %s not connected", req.InstanceID)
+	}
+
+	msg, messageType, mimetype, fileName, err := buildDownloadableMessage(req)
+	if err != nil {
+		return nil, err
+	}
+	if msg == nil {
+		return nil, fmt.Errorf("request does not contain a supported media message")
+	}
+
+	data, err := client.Download(ctx, msg)
+	if err != nil {
+		return nil, fmt.Errorf("whatsmeow download failed: %w", err)
+	}
+
+	return &DownloadMediaResponse{
+		MessageType: messageType,
+		Mimetype:    mimetype,
+		FileName:    fileName,
+		Base64:      base64.StdEncoding.EncodeToString(data),
+	}, nil
+}
+
+// buildDownloadableMessage picks the first non-nil media field and returns a
+// fully populated whatsmeow.DownloadableMessage plus metadata for the response.
+func buildDownloadableMessage(req *DownloadMediaRequest) (whatsmeow.DownloadableMessage, string, string, string, error) {
+	switch {
+	case req.ImageMessage != nil:
+		m, err := fillImage(req.ImageMessage)
+		return m, "imageMessage", req.ImageMessage.Mimetype, "", err
+	case req.StickerMessage != nil:
+		m, err := fillSticker(req.StickerMessage)
+		return m, "stickerMessage", req.StickerMessage.Mimetype, "", err
+	case req.AudioMessage != nil:
+		m, err := fillAudio(req.AudioMessage)
+		return m, "audioMessage", req.AudioMessage.Mimetype, "", err
+	case req.VideoMessage != nil:
+		m, err := fillVideo(req.VideoMessage)
+		return m, "videoMessage", req.VideoMessage.Mimetype, "", err
+	case req.DocumentMessage != nil:
+		m, err := fillDocument(req.DocumentMessage)
+		return m, "documentMessage", req.DocumentMessage.Mimetype, req.DocumentMessage.FileName, err
+	}
+	return nil, "", "", "", nil
+}
+
+func fillImage(f *DownloadableFields) (*waProto.ImageMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.ImageMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillAudio(f *DownloadableFields) (*waProto.AudioMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.AudioMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillVideo(f *DownloadableFields) (*waProto.VideoMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.VideoMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillDocument(f *DownloadableFields) (*waProto.DocumentMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.DocumentMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		FileName:          strPtrOrNil(f.FileName),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func fillSticker(f *DownloadableFields) (*waProto.StickerMessage, error) {
+	mediaKey, encHash, plainHash, err := decodeBinaryFields(f)
+	if err != nil {
+		return nil, err
+	}
+	return &waProto.StickerMessage{
+		URL:               proto.String(f.URL),
+		Mimetype:          strPtrOrNil(f.Mimetype),
+		DirectPath:        proto.String(f.DirectPath),
+		MediaKey:          mediaKey,
+		FileEncSHA256:     encHash,
+		FileSHA256:        plainHash,
+		MediaKeyTimestamp: toInt64Ptr(f.MediaKeyTimestamp),
+		FileLength:        toUint64Ptr(f.FileLength),
+	}, nil
+}
+
+func decodeBinaryFields(f *DownloadableFields) ([]byte, []byte, []byte, error) {
+	mediaKey, err := decodeBase64Field("mediaKey", f.MediaKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	encHash, err := decodeBase64Field("fileEncSha256", f.FileEncSHA256)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	plainHash, err := decodeBase64Field("fileSha256", f.FileSHA256)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return mediaKey, encHash, plainHash, nil
+}
+
+func decodeBase64Field(name, v string) ([]byte, error) {
+	if v == "" {
+		return nil, nil
+	}
+	// Tolerate URL-safe base64 as well.
+	v = bytes.NewBufferString(v).String()
+	if data, err := base64.StdEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.URLEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.RawStdEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	if data, err := base64.RawURLEncoding.DecodeString(v); err == nil {
+		return data, nil
+	}
+	return nil, fmt.Errorf("invalid base64 for field %s", name)
+}
+
+func strPtrOrNil(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return proto.String(v)
+}
+
+func toInt64Ptr(v any) *int64 {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		n := int64(x)
+		return &n
+	case int:
+		n := int64(x)
+		return &n
+	case int64:
+		return &x
+	case string:
+		if n, err := strconv.ParseInt(x, 10, 64); err == nil {
+			return &n
+		}
+	}
+	return nil
+}
+
+func toUint64Ptr(v any) *uint64 {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		n := uint64(x)
+		return &n
+	case int:
+		n := uint64(x)
+		return &n
+	case uint64:
+		return &x
+	case string:
+		if n, err := strconv.ParseUint(x, 10, 64); err == nil {
+			return &n
+		}
+	}
+	return nil
+}

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -455,15 +455,28 @@ func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance,
 		}
 	}
 
-	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado)
+	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado).
+	// Executa em goroutine para não bloquear o event loop: em contas antigas
+	// o HistorySync pode trazer dezenas de milhares de mensagens.
 	if eventMap["MESSAGES_UPSERT"] {
-		s.emitHistoryMessages(id, instance, e)
+		go s.emitHistoryMessages(id, instance, e)
 	}
 }
 
 func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e *events.HistorySync) {
 	ctx, c := context.WithTimeout(context.Background(), time.Minute*5)
 	defer c()
+
+	// Carrega o client uma vez — evita map lookup por mensagem.
+	client, ok := s.clients.Load(id)
+	if !ok {
+		return
+	}
+
+	var ownJid string
+	if own := client.Store.ID; own != nil {
+		ownJid = own.ToNonAD().String()
+	}
 
 	total := 0
 	for _, conv := range e.Data.GetConversations() {
@@ -478,6 +491,9 @@ func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e 
 		if err != nil {
 			continue
 		}
+
+		// JID/LID é constante dentro da conversa — resolve uma vez só.
+		jid, lid := s.GetJidLid(ctx, id, chatJid)
 
 		for _, histMsg := range conv.GetMessages() {
 			webMsgInfo := histMsg.GetMessage()
@@ -501,15 +517,11 @@ func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e 
 				continue
 			}
 
-			jid, lid := s.GetJidLid(ctx, id, chatJid)
-
 			// Sender (pode ser o próprio chat em 1-1, ou Participant em grupos)
 			senderJid := jid
 			if key.GetFromMe() {
-				if client, ok := s.clients.Load(id); ok {
-					if own := client.Store.ID; own != nil {
-						senderJid = own.ToNonAD().String()
-					}
+				if ownJid != "" {
+					senderJid = ownJid
 				}
 			} else if p := key.GetParticipant(); p != "" {
 				if pJid, perr := types.ParseJID(p); perr == nil {

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -441,23 +441,134 @@ func (s *Whatsmiau) handlePictureEvent(id string, instance *models.Instance, e *
 }
 
 func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance, e *events.HistorySync, eventMap map[string]bool) {
-	if !eventMap["CONTACTS_UPSERT"] {
-		return
+	// Emitir contatos (comportamento original)
+	if eventMap["CONTACTS_UPSERT"] {
+		data := s.convertContactHistorySync(id, e.Data.GetPushnames(), e.Data.Conversations)
+		if data != nil {
+			wookData := &WookEvent[WookContactUpsertData]{
+				Instance: instance.ID,
+				Data:     &data,
+				DateTime: time.Now(),
+				Event:    WookContactsUpsert,
+			}
+			s.emit(wookData, instance.Webhook.Url)
+		}
 	}
 
-	data := s.convertContactHistorySync(id, e.Data.GetPushnames(), e.Data.Conversations)
-	if data == nil {
-		return
+	// Emitir mensagens do histórico (novo — só se MESSAGES_UPSERT estiver habilitado)
+	if eventMap["MESSAGES_UPSERT"] {
+		s.emitHistoryMessages(id, instance, e)
+	}
+}
+
+func (s *Whatsmiau) emitHistoryMessages(id string, instance *models.Instance, e *events.HistorySync) {
+	ctx, c := context.WithTimeout(context.Background(), time.Minute*5)
+	defer c()
+
+	total := 0
+	for _, conv := range e.Data.GetConversations() {
+		// Ignorar grupos se configurado
+		if instance.GroupsIgnore {
+			if strings.Contains(conv.GetID(), "@g.us") {
+				continue
+			}
+		}
+
+		chatJid, err := types.ParseJID(conv.GetID())
+		if err != nil {
+			continue
+		}
+
+		for _, histMsg := range conv.GetMessages() {
+			webMsgInfo := histMsg.GetMessage()
+			if webMsgInfo == nil || webMsgInfo.GetMessage() == nil {
+				continue
+			}
+
+			key := webMsgInfo.GetKey()
+			if key == nil {
+				continue
+			}
+
+			msg := webMsgInfo.GetMessage()
+			// Ignorar mensagens de protocolo (criptografia, etc)
+			if msg.GetProtocolMessage() != nil {
+				continue
+			}
+
+			messageType, raw, ci := s.parseWAMessage(msg)
+			if raw == nil {
+				continue
+			}
+
+			jid, lid := s.GetJidLid(ctx, id, chatJid)
+
+			// Sender (pode ser o próprio chat em 1-1, ou Participant em grupos)
+			senderJid := jid
+			if key.GetFromMe() {
+				if client, ok := s.clients.Load(id); ok {
+					if own := client.Store.ID; own != nil {
+						senderJid = own.ToNonAD().String()
+					}
+				}
+			} else if p := key.GetParticipant(); p != "" {
+				if pJid, perr := types.ParseJID(p); perr == nil {
+					senderJid, _ = s.GetJidLid(ctx, id, pJid)
+				}
+			}
+
+			wookKey := &WookKey{
+				RemoteJid:   jid,
+				RemoteLid:   lid,
+				FromMe:      key.GetFromMe(),
+				Id:          key.GetID(),
+				Participant: senderJid,
+			}
+
+			status := "received"
+			if key.GetFromMe() {
+				status = "sent"
+			}
+
+			ts := time.Unix(int64(webMsgInfo.GetMessageTimestamp()), 0)
+
+			var messageContext WookMessageContextInfo
+			if ci != nil {
+				messageContext.StanzaId = ci.GetStanzaID()
+				messageContext.Participant = ci.GetParticipant()
+				if qm := ci.GetQuotedMessage(); qm != nil {
+					_, qmRaw, _ := s.parseWAMessage(qm)
+					messageContext.QuotedMessage = qmRaw
+				}
+			}
+
+			messageData := &WookMessageData{
+				Key:              wookKey,
+				PushName:         strings.TrimSpace(webMsgInfo.GetPushName()),
+				Status:           status,
+				Message:          raw,
+				ContextInfo:      &messageContext,
+				MessageType:      messageType,
+				MessageTimestamp: int(ts.Unix()),
+				InstanceId:       instance.ID,
+				Source:           "whatsapp-history",
+			}
+
+			wookMessage := &WookEvent[WookMessageData]{
+				Instance: instance.ID,
+				Data:     messageData,
+				DateTime: ts,
+				Event:    WookMessagesUpsert,
+			}
+
+			s.emit(wookMessage, instance.Webhook.Url)
+			total++
+		}
 	}
 
-	wookData := &WookEvent[WookContactUpsertData]{
-		Instance: instance.ID,
-		Data:     &data,
-		DateTime: time.Now(),
-		Event:    WookContactsUpsert,
+	if total > 0 {
+		zap.L().Info("history messages emitted", zap.String("instance", instance.ID), zap.Int("total", total))
 	}
-
-	s.emit(wookData, instance.Webhook.Url)
 }
 
 func (s *Whatsmiau) handleGroupInfoEvent(id string, instance *models.Instance, e *events.GroupInfo, eventMap map[string]bool) {

--- a/lib/whatsmiau/full_history.go
+++ b/lib/whatsmiau/full_history.go
@@ -1,0 +1,32 @@
+package whatsmiau
+
+import (
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	"go.mau.fi/whatsmeow/store"
+	"google.golang.org/protobuf/proto"
+)
+
+// init enables WhatsApp's "full history sync" handshake on all devices created
+// by this package.
+//
+// By default whatsmeow (and Baileys) only ask for the small initial bootstrap
+// that the phone is willing to send. Applications that need to import the
+// maximum amount of past conversations (for example when mirroring an
+// existing number into a new system) must opt in by setting RequireFullSync
+// and raising the HistorySyncConfig limits before whatsmeow.NewClient is
+// called. The upper bounds are gated by WhatsApp — whatsmeow only forwards
+// what the server decides to send — but asking for more is harmless and lets
+// big multi-device accounts receive more history.
+//
+// Setting it in init() ensures every call to container.NewDevice() (web pair,
+// recovery, re-pair after logout) inherits the same opt-in.
+func init() {
+	store.DeviceProps.RequireFullSync = proto.Bool(true)
+	store.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{
+		FullSyncDaysLimit:                proto.Uint32(3650),
+		FullSyncSizeMbLimit:              proto.Uint32(51200),
+		StorageQuotaMb:                   proto.Uint32(51200),
+		InlineInitialPayloadInE2EeMsg:    proto.Bool(true),
+		SupportBotUserAgentChatHistory:   proto.Bool(true),
+	}
+}

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -78,6 +78,57 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 	}, nil
 }
 
+type SendLocationRequest struct {
+	InstanceID string     `json:"instance_id"`
+	RemoteJID  *types.JID `json:"remote_jid"`
+	Latitude   float64    `json:"latitude"`
+	Longitude  float64    `json:"longitude"`
+	Name       string     `json:"name"`
+	Address    string     `json:"address"`
+}
+
+type SendLocationResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (s *Whatsmiau) SendLocation(ctx context.Context, data *SendLocationRequest) (*SendLocationResponse, error) {
+	client, ok := s.clients.Load(data.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if data.RemoteJID == nil {
+		return nil, fmt.Errorf("remote_jid is required")
+	}
+
+	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
+	data.RemoteJID = &resolved
+
+	locMessage := &waE2E.LocationMessage{
+		DegreesLatitude:  proto.Float64(data.Latitude),
+		DegreesLongitude: proto.Float64(data.Longitude),
+	}
+	if data.Name != "" {
+		locMessage.Name = proto.String(data.Name)
+	}
+	if data.Address != "" {
+		locMessage.Address = proto.String(data.Address)
+	}
+
+	res, err := client.SendMessage(ctx, *data.RemoteJID, &waE2E.Message{
+		LocationMessage: locMessage,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendLocationResponse{
+		ID:        res.ID,
+		CreatedAt: res.Timestamp,
+	}, nil
+}
+
 type SendAudioRequest struct {
 	AudioURL       string     `json:"text"`
 	InstanceID     string     `json:"instance_id"`

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -147,6 +147,47 @@ func (s *Chat) SendChatPresence(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, map[string]interface{}{})
 }
 
+// GetBase64FromMediaMessage godoc
+// @Summary      Download media as base64
+// @Description  Downloads and decrypts a media message (image/audio/video/document/sticker)
+//
+//	using the downloadable fields previously delivered via webhook and returns
+//	it as base64-encoded bytes. Response shape mirrors Evolution API's
+//	/chat/getBase64FromMediaMessage for drop-in compatibility.
+//
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                        true  "Instance ID"
+// @Param        body      body      whatsmiau.DownloadMediaRequest true "Media fields"
+// @Success      200       {object}  whatsmiau.DownloadMediaResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      404       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /chat/getBase64FromMediaMessage/{instance} [post]
+func (s *Chat) GetBase64FromMediaMessage(ctx echo.Context) error {
+	instanceID := ctx.Param("instance")
+	if instanceID == "" {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "instance ID is required in the URL path")
+	}
+
+	var request whatsmiau.DownloadMediaRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	request.InstanceID = instanceID
+
+	resp, err := s.whatsmiau.DownloadMedia(ctx.Request().Context(), &request)
+	if err != nil {
+		zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
 // NumberExists godoc
 // @Summary      Check if numbers exist on WhatsApp
 // @Description  Checks whether the given phone numbers are registered on WhatsApp

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -181,8 +182,18 @@ func (s *Chat) GetBase64FromMediaMessage(ctx echo.Context) error {
 
 	resp, err := s.whatsmiau.DownloadMedia(ctx.Request().Context(), &request)
 	if err != nil {
-		zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
-		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+		// Client-side issues (malformed payload, bad base64, no media fields)
+		// map to 4xx. Genuine server/decryption failures stay 500.
+		switch {
+		case errors.Is(err, whatsmiau.ErrMediaFieldsMissing),
+			errors.Is(err, whatsmiau.ErrInvalidBase64):
+			return utils.HTTPFail(ctx, http.StatusBadRequest, err, err.Error())
+		case errors.Is(err, whatsmiau.ErrInstanceNotFound):
+			return utils.HTTPFail(ctx, http.StatusNotFound, err, err.Error())
+		default:
+			zap.L().Error("Whatsmiau.DownloadMedia failed", zap.Error(err))
+			return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to download media")
+		}
 	}
 
 	return ctx.JSON(http.StatusOK, resp)

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
 	"github.com/verbeux-ai/whatsmiau/server/dto"
 	"github.com/verbeux-ai/whatsmiau/utils"
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
 	"go.uber.org/zap"
 )
@@ -238,4 +239,55 @@ func (s *Chat) NumberExists(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, response)
+}
+
+// FetchProfilePictureUrl godoc
+// @Summary      Fetch WhatsApp profile picture URL
+// @Description  Returns the full-resolution profile picture URL for a given number. Evolution API compatible.
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                              true  "Instance ID"
+// @Param        body      body      dto.FetchProfilePictureUrlRequest   true  "Number to look up"
+// @Success      200       {object}  dto.FetchProfilePictureUrlResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      404       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /chat/fetchProfilePictureUrl/{instance} [post]
+func (s *Chat) FetchProfilePictureUrl(ctx echo.Context) error {
+	instanceID := ctx.Param("instance")
+	if instanceID == "" {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "instance ID is required in the URL path")
+	}
+
+	var request dto.FetchProfilePictureUrlRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	response, err := s.whatsmiau.FetchProfilePictureUrl(ctx.Request().Context(), &whatsmiau.FetchProfilePictureUrlRequest{
+		InstanceID: instanceID,
+		Number:     request.Number,
+	})
+	if err != nil {
+		if errors.Is(err, whatsmeow.ErrClientIsNil) {
+			return utils.HTTPFail(ctx, http.StatusNotFound, err, "instance not found or not connected")
+		}
+		if errors.Is(err, whatsmiau.ErrEmptyNumber) {
+			return utils.HTTPFail(ctx, http.StatusBadRequest, err, "number is empty")
+		}
+		zap.L().Error("Whatsmiau.FetchProfilePictureUrl failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to fetch profile picture")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.FetchProfilePictureUrlResponse{
+		Wuid:              response.Wuid,
+		ProfilePictureURL: response.ProfilePictureURL,
+	})
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -99,7 +99,7 @@ func (s *Message) SendText(ctx echo.Context) error {
 			Conversation: request.Text,
 		},
 		MessageType:      "conversation",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -173,7 +173,7 @@ func (s *Message) SendAudio(ctx echo.Context) error {
 
 		Status:           "sent",
 		MessageType:      "audioMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -270,7 +270,7 @@ func (s *Message) sendDocument(ctx echo.Context, request dto.SendDocumentRequest
 		},
 		Status:           "sent",
 		MessageType:      "documentMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -334,7 +334,7 @@ func (s *Message) sendImage(ctx echo.Context, request dto.SendDocumentRequest) e
 		},
 		Status:           "sent",
 		MessageType:      "imageMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -485,7 +485,7 @@ func (s *Message) SendList(ctx echo.Context) error {
 		},
 		Status:           "sent",
 		MessageType:      "listMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -588,7 +588,7 @@ func (s *Message) sendReplyButtons(ctx echo.Context, c context.Context, request 
 		},
 		Status:           "sent",
 		MessageType:      "buttonsMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -627,7 +627,7 @@ func (s *Message) sendPixButtons(ctx echo.Context, c context.Context, request dt
 		},
 		Status:           "sent",
 		MessageType:      "buttonsMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -99,7 +99,7 @@ func (s *Message) SendText(ctx echo.Context) error {
 			Conversation: request.Text,
 		},
 		MessageType:      "conversation",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -173,7 +173,7 @@ func (s *Message) SendAudio(ctx echo.Context) error {
 
 		Status:           "sent",
 		MessageType:      "audioMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -270,7 +270,7 @@ func (s *Message) sendDocument(ctx echo.Context, request dto.SendDocumentRequest
 		},
 		Status:           "sent",
 		MessageType:      "documentMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -334,7 +334,7 @@ func (s *Message) sendImage(ctx echo.Context, request dto.SendDocumentRequest) e
 		},
 		Status:           "sent",
 		MessageType:      "imageMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -397,7 +397,7 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 		},
 		Status:           "sent",
 		MessageType:      "reactionMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMicro() / 1000),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -485,7 +485,7 @@ func (s *Message) SendList(ctx echo.Context) error {
 		},
 		Status:           "sent",
 		MessageType:      "listMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -588,7 +588,7 @@ func (s *Message) sendReplyButtons(ctx echo.Context, c context.Context, request 
 		},
 		Status:           "sent",
 		MessageType:      "buttonsMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }
@@ -627,7 +627,7 @@ func (s *Message) sendPixButtons(ctx echo.Context, c context.Context, request dt
 		},
 		Status:           "sent",
 		MessageType:      "buttonsMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -157,7 +157,7 @@ func (s *Message) SendLocation(ctx echo.Context) error {
 		},
 		Status:           "sent",
 		MessageType:      "locationMessage",
-		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
 		InstanceId:       request.InstanceID,
 	})
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -157,7 +157,7 @@ func (s *Message) SendLocation(ctx echo.Context) error {
 		},
 		Status:           "sent",
 		MessageType:      "locationMessage",
-		MessageTimestamp: int(res.CreatedAt.UnixMilli()),
+		MessageTimestamp: res.CreatedAt.UnixMilli(),
 		InstanceId:       request.InstanceID,
 	})
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -104,6 +104,64 @@ func (s *Message) SendText(ctx echo.Context) error {
 	})
 }
 
+// SendLocation godoc
+// @Summary      Send a location pin
+// @Description  Sends a location pin (latitude/longitude with optional name and address) to a WhatsApp number
+// @Tags         Message
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                 true  "Instance ID"
+// @Param        body      body      dto.SendLocationRequest true  "Location parameters"
+// @Success      200       {object}  dto.SendLocationResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /instance/{instance}/message/location [post]
+// @Router       /message/sendLocation/{instance} [post]
+func (s *Message) SendLocation(ctx echo.Context) error {
+	var request dto.SendLocationRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	jid, err := numberToJid(request.Number)
+	if err != nil {
+		zap.L().Error("error converting number to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
+	}
+
+	c := ctx.Request().Context()
+	res, err := s.whatsmiau.SendLocation(c, &whatsmiau.SendLocationRequest{
+		InstanceID: request.InstanceID,
+		RemoteJID:  jid,
+		Latitude:   request.Latitude,
+		Longitude:  request.Longitude,
+		Name:       request.Name,
+		Address:    request.Address,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.SendLocation failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to send location")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.SendLocationResponse{
+		Key: dto.MessageResponseKey{
+			RemoteJid: request.Number,
+			FromMe:    true,
+			Id:        res.ID,
+		},
+		Status:           "sent",
+		MessageType:      "locationMessage",
+		MessageTimestamp: int(res.CreatedAt.Unix() / 1000),
+		InstanceId:       request.InstanceID,
+	})
+}
+
 // SendAudio godoc
 // @Summary      Send an audio message
 // @Description  Sends an audio file (by URL) as a WhatsApp voice message to the specified number

--- a/server/dto/chat.go
+++ b/server/dto/chat.go
@@ -40,3 +40,16 @@ type SendChatPresenceResponse struct {
 type NumberExistsRequest struct {
 	Numbers []string `json:"numbers"     validate:"required,min=1,dive,required"`
 }
+
+// FetchProfilePictureUrlRequest mirrors the Evolution API v2 payload for
+// POST /chat/fetchProfilePictureUrl/{instance}.
+type FetchProfilePictureUrlRequest struct {
+	Number string `json:"number" validate:"required"`
+}
+
+// FetchProfilePictureUrlResponse mirrors Evolution's response shape so the
+// same client code works unchanged against both backends.
+type FetchProfilePictureUrlResponse struct {
+	Wuid              string `json:"wuid"`
+	ProfilePictureURL string `json:"profilePictureUrl"`
+}

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -24,7 +24,7 @@ type SendLocationResponse struct {
 	Key              MessageResponseKey `json:"key"`
 	Status           string             `json:"status"`
 	MessageType      string             `json:"messageType"`
-	MessageTimestamp int                `json:"messageTimestamp"`
+	MessageTimestamp int64              `json:"messageTimestamp"`
 	InstanceId       string             `json:"instanceId"`
 }
 

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -37,7 +37,7 @@ type SendTextResponse struct {
 	Message          SendTextResponseMessage     `json:"message"`
 	ContextInfo      SendTextResponseContextInfo `json:"contextInfo"`
 	MessageType      string                      `json:"messageType"`
-	MessageTimestamp int                         `json:"messageTimestamp"`
+	MessageTimestamp int64                         `json:"messageTimestamp"`
 	InstanceId       string                      `json:"instanceId"`
 	Source           string                      `json:"source"`
 }
@@ -90,7 +90,7 @@ type SendAudioResponse struct {
 	InstanceId       string                   `json:"instanceId"`
 	Key              MessageResponseKey       `json:"key"`
 	Message          SendAudioResponseMessage `json:"message"`
-	MessageTimestamp int                      `json:"messageTimestamp"`
+	MessageTimestamp int64                      `json:"messageTimestamp"`
 	MessageType      string                   `json:"messageType"`
 	PushName         string                   `json:"pushName"`
 	Source           string                   `json:"source"`
@@ -147,7 +147,7 @@ type SendDocumentResponse struct {
 	Message          SendDocumentResponseData `json:"message,omitempty"`
 	ContextInfo      any                      `json:"contextInfo,omitempty"`
 	MessageType      string                   `json:"messageType,omitempty"`
-	MessageTimestamp int                      `json:"messageTimestamp,omitempty"`
+	MessageTimestamp int64                      `json:"messageTimestamp,omitempty"`
 	InstanceId       string                   `json:"instanceId,omitempty"`
 	Source           string                   `json:"source,omitempty"`
 }
@@ -186,7 +186,7 @@ type SendReactionResponse struct {
 	Key              MessageResponseKey `json:"key"`
 	ContextInfo      any                `json:"contextInfo,omitempty"`
 	MessageType      string             `json:"messageType,omitempty"`
-	MessageTimestamp int                `json:"messageTimestamp,omitempty"`
+	MessageTimestamp int64                `json:"messageTimestamp,omitempty"`
 	InstanceId       string             `json:"instanceId,omitempty"`
 	Source           string             `json:"source,omitempty"`
 	Status           string             `json:"status,omitempty"`
@@ -220,7 +220,7 @@ type SendListResponse struct {
 	Key              MessageResponseKey `json:"key"`
 	Status           string             `json:"status"`
 	MessageType      string             `json:"messageType"`
-	MessageTimestamp int                `json:"messageTimestamp"`
+	MessageTimestamp int64                `json:"messageTimestamp"`
 	InstanceId       string             `json:"instanceId"`
 }
 
@@ -251,6 +251,6 @@ type SendButtonsResponse struct {
 	Key              MessageResponseKey `json:"key"`
 	Status           string             `json:"status"`
 	MessageType      string             `json:"messageType"`
-	MessageTimestamp int                `json:"messageTimestamp"`
+	MessageTimestamp int64                `json:"messageTimestamp"`
 	InstanceId       string             `json:"instanceId"`
 }

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -11,6 +11,23 @@ type SendTextRequest struct {
 	Mentioned        []string              `json:"mentioned,omitempty"`
 }
 
+type SendLocationRequest struct {
+	InstanceID string  `param:"instance" validate:"required" swaggerignore:"true"`
+	Number     string  `json:"number,omitempty" validate:"required"`
+	Latitude   float64 `json:"latitude" validate:"required"`
+	Longitude  float64 `json:"longitude" validate:"required"`
+	Name       string  `json:"name,omitempty"`
+	Address    string  `json:"address,omitempty"`
+}
+
+type SendLocationResponse struct {
+	Key              MessageResponseKey `json:"key"`
+	Status           string             `json:"status"`
+	MessageType      string             `json:"messageType"`
+	MessageTimestamp int                `json:"messageTimestamp"`
+	InstanceId       string             `json:"instanceId"`
+}
+
 type MessageRequestQuoted struct {
 	Key     QuotedKey     `json:"key,omitempty"`
 	Message QuotedMessage `json:"message,omitempty"`

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -15,6 +15,7 @@ func Chat(group *echo.Group) {
 	group.POST("/presence", controller.SendChatPresence)
 	group.POST("/read-messages", controller.ReadMessages)
 	group.POST("/download-media", controller.GetBase64FromMediaMessage)
+	group.POST("/profile-picture-url", controller.FetchProfilePictureUrl)
 }
 
 func ChatEVO(group *echo.Group) {
@@ -26,4 +27,5 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/sendPresence/:instance", controller.SendChatPresence)
 	group.POST("/whatsappNumbers/:instance", controller.NumberExists)
 	group.POST("/getBase64FromMediaMessage/:instance", controller.GetBase64FromMediaMessage)
+	group.POST("/fetchProfilePictureUrl/:instance", controller.FetchProfilePictureUrl)
 }

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -14,6 +14,7 @@ func Chat(group *echo.Group) {
 
 	group.POST("/presence", controller.SendChatPresence)
 	group.POST("/read-messages", controller.ReadMessages)
+	group.POST("/download-media", controller.GetBase64FromMediaMessage)
 }
 
 func ChatEVO(group *echo.Group) {
@@ -24,4 +25,5 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/markMessageAsRead/:instance", controller.ReadMessages)
 	group.POST("/sendPresence/:instance", controller.SendChatPresence)
 	group.POST("/whatsappNumbers/:instance", controller.NumberExists)
+	group.POST("/getBase64FromMediaMessage/:instance", controller.GetBase64FromMediaMessage)
 }

--- a/server/routes/message.go
+++ b/server/routes/message.go
@@ -18,6 +18,7 @@ func Message(group *echo.Group) {
 	group.POST("/image", controller.SendImage)
 	group.POST("/list", controller.SendList)
 	group.POST("/buttons", controller.SendButtons)
+	group.POST("/location", controller.SendLocation)
 }
 
 func MessageEVO(group *echo.Group) {
@@ -31,4 +32,5 @@ func MessageEVO(group *echo.Group) {
 	group.POST("/sendReaction/:instance", controller.SendReaction)
 	group.POST("/sendList/:instance", controller.SendList)
 	group.POST("/sendButtons/:instance", controller.SendButtons)
+	group.POST("/sendLocation/:instance", controller.SendLocation)
 }


### PR DESCRIPTION
## What

Exposes [whatsmeow's `client.GetProfilePictureInfo`](https://pkg.go.dev/go.mau.fi/whatsmeow#Client.GetProfilePictureInfo) as a new HTTP endpoint that mirrors Evolution API v2's `POST /chat/fetchProfilePictureUrl/{instance}` — drop-in compatible so existing Evolution-based clients work unchanged.

Two routes added:
- `POST /v1/chat/fetchProfilePictureUrl/{instance}` — Evolution compat (path param)
- `POST /v1/chat/profile-picture-url` — native style (instance in body)

### Request
```json
{ "number": "5511999998888" }
```
Also accepts already-formatted JIDs (`5511999998888@s.whatsapp.net`, group JIDs, etc.)

### Response
```json
{
  "wuid": "5511999998888@s.whatsapp.net",
  "profilePictureUrl": "https://pps.whatsapp.net/v/..."
}
```

## Why

Apps built on top of Evolution API's surface need to refresh a contact's profile picture on demand — e.g. when the user opens a conversation in the UI. The `GetProfilePictureInfo` primitive is already used internally by `event_emitter.go` (`getPic` helper); this PR only exposes it over HTTP.

## Behavior

- Uses `Preview: false` — returns the full-resolution image URL
- For plain numbers, falls back to `resolveJID` (existing helper) to handle the Brazilian 9th-digit quirk
- When the profile exists but the picture isn't visible (privacy settings, no avatar set), returns **empty URL** instead of 500, so clients can gracefully hide the avatar
- Validation via `go-playground/validator` same as other endpoints
- New sentinel error `whatsmiau.ErrEmptyNumber` → HTTP 400 when number is blank
- Maps `whatsmeow.ErrClientIsNil` → HTTP 404 (instance not found or not connected)

## Files

- `lib/whatsmiau/chat.go` — `FetchProfilePictureUrl` method + `ErrEmptyNumber`
- `server/dto/chat.go` — `FetchProfilePictureUrlRequest`/`Response` DTOs
- `server/controllers/chat.go` — HTTP handler
- `server/routes/chat.go` — 2 route registrations

## Test plan

- [x] `go build ./...` clean
- [ ] Manual: `curl -X POST -H 'apikey: $KEY' -H 'Content-Type: application/json' -d '{"number":"5511999999999"}' http://localhost:8080/v1/chat/fetchProfilePictureUrl/INSTANCE`
- [ ] Manual: contato sem foto → retorna `profilePictureUrl: ""`
- [ ] Manual: instância desconectada → 404
- [ ] Manual: número em branco → 400

---

Follows the same pattern of previous PRs (#41, #42, #43, #44) from the same author.