### PR TITLE
fix: reações em mensagens recebidas e remoção de reação

### DIFF
--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -309,10 +309,6 @@ func (s *Whatsmiau) SendReaction(ctx context.Context, data *SendReactionRequest)
 		return nil, fmt.Errorf("remote_jid is required")
 	}
 
-	if len(data.Reaction) <= 0 {
-		return nil, fmt.Errorf("empty reaction, len: %d", len(data.Reaction))
-	}
-
 	if len(data.MessageID) <= 0 {
 		return nil, fmt.Errorf("invalid message_id")
 	}

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -369,9 +369,11 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
-	var emojiRegex = regexp.MustCompile(`[\x{1F600}-\x{1F64F}]|[\x{1F300}-\x{1F5FF}]|[\x{1F680}-\x{1F6FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]`)
-	if !emojiRegex.MatchString(request.Reaction) {
-		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid reaction, must be a emoji")
+	if request.Reaction != "" {
+		var emojiRegex = regexp.MustCompile(`[\x{1F600}-\x{1F64F}]|[\x{1F300}-\x{1F5FF}]|[\x{1F680}-\x{1F6FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]`)
+		if !emojiRegex.MatchString(request.Reaction) {
+			return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "invalid reaction, must be a emoji")
+		}
 	}
 
 	sendReaction := &whatsmiau.SendReactionRequest{
@@ -379,7 +381,7 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 		Reaction:   request.Reaction,
 		RemoteJID:  jid,
 		MessageID:  request.Key.Id,
-		FromMe:     request.Key.FromMe,
+		FromMe:     *request.Key.FromMe,
 	}
 
 	c := ctx.Request().Context()
@@ -392,7 +394,7 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, dto.SendReactionResponse{
 		Key: dto.MessageResponseKey{
 			RemoteJid: request.Key.RemoteJid,
-			FromMe:    true,
+			FromMe:    *request.Key.FromMe,
 			Id:        res.ID,
 		},
 		Status:           "sent",

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -29,6 +29,8 @@ func NewMessages(repository interfaces.InstanceRepository, whatsmiau *whatsmiau.
 	}
 }
 
+var emojiRegex = regexp.MustCompile(`[\x{1F600}-\x{1F64F}]|[\x{1F300}-\x{1F5FF}]|[\x{1F680}-\x{1F6FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]`)
+
 // SendText godoc
 // @Summary      Send a text message
 // @Description  Sends a text message to a WhatsApp number via the specified instance
@@ -369,11 +371,8 @@ func (s *Message) SendReaction(ctx echo.Context) error {
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
-	if request.Reaction != "" {
-		var emojiRegex = regexp.MustCompile(`[\x{1F600}-\x{1F64F}]|[\x{1F300}-\x{1F5FF}]|[\x{1F680}-\x{1F6FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]`)
-		if !emojiRegex.MatchString(request.Reaction) {
-			return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "invalid reaction, must be a emoji")
-		}
+	if request.Reaction != "" && !emojiRegex.MatchString(request.Reaction) {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "invalid reaction, must be a emoji")
 	}
 
 	sendReaction := &whatsmiau.SendReactionRequest{

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -174,11 +174,11 @@ type SendDocumentResponseDataImage struct {
 
 type SendReactionRequest struct {
 	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
-	Reaction   string `json:"reaction,omitempty" validate:"required,len=1"`
+	Reaction   string `json:"reaction" validate:"max=10"`
 	Key        struct {
 		RemoteJid string `json:"remoteJid,omitempty" validate:"required"`
 		Id        string `json:"id,omitempty" validate:"required"`
-		FromMe    bool   `json:"fromMe,omitempty" validate:"required"`
+		FromMe    *bool  `json:"fromMe,omitempty" validate:"required"`
 	} `json:"key"`
 }
 


### PR DESCRIPTION
## Contexto

Três sintomas reportados em reações (emoji) no WhatsApp:

1. **Reagir a mensagem recebida do cliente** (`FromMe=false`) **não chegava** no WhatsApp do cliente.
2. **Reagir à própria mensagem** (`FromMe=true`) funcionava, mas **remover** a reação (emoji vazio) **não removia**.
3. Recepção (cliente → servidor) funciona normalmente — sem alterações aqui.

## Diagnóstico

### Bug 1 — `FromMe=false` barrado na validação

`dto/message.go` declarava `FromMe bool` com tag `validate:"required"`. O `go-playground/validator` trata `required` em `bool` como "não pode ser zero-value" → `false` sempre falhava a validação, retornando 400 antes mesmo de chegar na lib. Reagir a msg recebida nunca saía.

### Bug 2 — Remoção (Text=`""`) bloqueada em 3 camadas

Protocolo WhatsApp remove reação com `ReactionMessage{Text: ""}`. A string vazia era rejeitada em:

- DTO: `validate:"required,len=1"`
- Controller: regex de emoji não casa com `""`
- Lib: `if len(Reaction) <= 0 { return err }`

O `BuildReaction` do whatsmeow aceitaria `""` normalmente, mas o request nunca chegava lá.

### Bônus

Response do controller retornava `FromMe: true` hardcoded em vez do valor do input.

## Mudanças

- `server/dto/message.go` — `FromMe bool` → `*bool`; `Reaction` afrouxado para `validate:"max=10"` (suporta `""` e emojis multi-rune ZWJ).
- `server/controllers/message.go` — regex de emoji só roda quando `Reaction != ""`; `FromMe` propagado via ponteiro tanto na chamada à lib quanto no response.
- `lib/whatsmiau/send.go` — removido guard de reação vazia.

Lógica de `sender` em `send.go` já estava correta — `BuildMessageKey` do whatsmeow usa o `sender.User` para decidir o `FromMe` da key.

## Test plan

- [x] Subir whatsmiau local e parear instância
- [x] Reagir com emoji a mensagem **recebida** do cliente → confirmar que aparece no WhatsApp do cliente
- [x] Reagir com emoji a mensagem **própria** enviada → confirmar que aparece no WhatsApp do cliente
- [x] Enviar `"reaction": ""` para o mesmo `messageId` em ambos os casos acima → confirmar que a reação some do WhatsApp do cliente
- [x] Regressão: cliente reage/remove em conversa → webhook `messages.upsert` continua chegando com `message.reactionMessage.text` contendo emoji ou `""`
- [x] Response HTTP de `POST /message/sendReaction/{instance}` reflete o `fromMe` enviado na request

## Breaking change?

Mudar `FromMe bool` para `*bool` no DTO significa que **clients que antes omitiam o campo `fromMe`** agora recebem 400 (o `required` em `*bool` exige presença). Antes, omitir → default `false` → já dava 400 pelo mesmo motivo do Bug 1. Logo, nenhum cliente funcional hoje quebra. Clientes que enviavam `"fromMe": true` continuam funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)