### PR TITLE
feat: add group and community management endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -309,6 +309,716 @@ const docTemplate = `{
                 }
             }
         },
+        "/group/acceptInviteCode/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Join a group using an invite code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.AcceptGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/create/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create a WhatsApp group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/fetchAllGroups/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List all joined groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Include participants (true/false)",
+                        "name": "getParticipants",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/group/findGroupInfos/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get group info by JID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/inviteCode/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get the group invite code (link)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/inviteInfo/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get info about an invite code (no join)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/leaveGroup/{instance}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Leave a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/participants/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List participants of a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.FindParticipantsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/revokeInviteCode/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Revoke current invite code and generate a new one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupRevokeInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/sendInvite/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Send group invite link via text to phone numbers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSendInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SendGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/toggleEphemeral/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle disappearing messages for the group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Ephemeral payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupToggleEphemeralRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupDescription/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group description",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Description payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupDescriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupPicture/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group picture",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Picture payload (base64 or URL)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupPictureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SetGroupPictureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupSubject/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group subject (name)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subject payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSubjectRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateParticipant/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group participants (add/remove/promote/demote)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateParticipantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateSetting/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group setting (announce/locked)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/instance": {
             "get": {
                 "security": [
@@ -1253,6 +1963,1164 @@ const docTemplate = `{
                 }
             }
         },
+        "/instance/{instance}/community/create": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Create a WhatsApp community (parent group)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Community payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateCommunityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/createSubGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Create a new group already linked to a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sub group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateCommunitySubGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/linkGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Link an existing group to a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityLinkGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/linkedGroupsParticipants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List participants across all linked groups of a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.LinkedParticipantResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/requestParticipants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List pending join requests",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.RequestParticipantResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/requestParticipants/update": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Approve or reject pending join requests",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityUpdateRequestParticipantsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/setJoinApprovalMode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Toggle join-approval mode for a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunitySetJoinApprovalModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/setMemberAddMode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunitySetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/subGroups": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List subgroups of a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.SubGroupResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/unlinkGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Remove a group from a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityLinkGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/acceptInviteCode": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Join a group using an invite code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.AcceptGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/create": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create a WhatsApp group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/fetchAllGroups": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List all joined groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Include participants (true/false)",
+                        "name": "getParticipants",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/findGroupInfos": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get group info by JID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/inviteCode": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get the group invite code (link)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/inviteInfo": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get info about an invite code (no join)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/leaveGroup": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Leave a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/participants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List participants of a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.FindParticipantsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/revokeInviteCode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Revoke current invite code and generate a new one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupRevokeInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/sendInvite": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Send group invite link via text to phone numbers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSendInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SendGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/toggleEphemeral": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle disappearing messages for the group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Ephemeral payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupToggleEphemeralRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupDescription": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group description",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Description payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupDescriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupPicture": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group picture",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Picture payload (base64 or URL)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupPictureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SetGroupPictureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupSubject": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group subject (name)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subject payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSubjectRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateParticipant": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group participants (add/remove/promote/demote)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateParticipantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateSetting": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group setting (announce/locked)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/audio": {
             "post": {
                 "security": [
@@ -1637,6 +3505,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/instance/{instance}/message/video": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a video file by URL to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a video",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Video parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendDocumentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendDocumentResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendButtons/{instance}": {
             "post": {
                 "security": [
@@ -1696,6 +3610,52 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendContact/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends contact cards (vCard) to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send one or more contacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Contact parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendContactResponse"
                         }
                     }
                 }
@@ -1765,6 +3725,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/message/sendLocation/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a geographic location to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a location message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendLocationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendLocationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendMedia/{instance}": {
             "post": {
                 "security": [
@@ -1829,6 +3835,98 @@ const docTemplate = `{
                 }
             }
         },
+        "/message/sendPoll/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a multiple-choice poll to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a poll",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Poll parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPollRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPollResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendPtv/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a round/circle video note to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a round video note (PTV)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "PTV parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPtvRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPtvResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendReaction/{instance}": {
             "post": {
                 "security": [
@@ -1888,6 +3986,98 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendStatus/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a status (text/image/audio/video) to status@broadcast",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a status broadcast",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStatusResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendSticker/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a WebP sticker to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a sticker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sticker parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStickerRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStickerResponse"
                         }
                     }
                 }
@@ -2023,6 +4213,81 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "dto.CommunityLinkGroupRequest": {
+            "type": "object",
+            "required": [
+                "childJid",
+                "parentJid"
+            ],
+            "properties": {
+                "childJid": {
+                    "type": "string"
+                },
+                "parentJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CommunitySetJoinApprovalModeRequest": {
+            "type": "object",
+            "required": [
+                "communityJid"
+            ],
+            "properties": {
+                "communityJid": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.CommunitySetMemberAddModeRequest": {
+            "type": "object",
+            "required": [
+                "communityJid",
+                "mode"
+            ],
+            "properties": {
+                "communityJid": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "admin_add",
+                        "all_member_add"
+                    ]
+                }
+            }
+        },
+        "dto.CommunityUpdateRequestParticipantsRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "communityJid",
+                "participants"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "approve",
+                        "reject"
+                    ]
+                },
+                "communityJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "dto.ConnectInstanceResponse": {
             "type": "object",
             "properties": {
@@ -2045,6 +4310,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "msgCall": {
+                    "type": "string"
+                },
+                "pairingCode": {
                     "type": "string"
                 },
                 "proxyHost": {
@@ -2093,6 +4361,74 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.CreateCommunityRequest": {
+            "type": "object",
+            "required": [
+                "subject"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.CreateCommunitySubGroupRequest": {
+            "type": "object",
+            "required": [
+                "parentJid",
+                "participants",
+                "subject"
+            ],
+            "properties": {
+                "parentJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.CreateGroupRequest": {
+            "type": "object",
+            "required": [
+                "participants",
+                "subject"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "promoteParticipants": {
+                    "type": "boolean"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
         "dto.CreateInstanceRequest": {
             "type": "object",
             "properties": {
@@ -2107,6 +4443,9 @@ const docTemplate = `{
                 },
                 "instanceName": {
                     "type": "string"
+                },
+                "migration": {
+                    "$ref": "#/definitions/dto.MigrationData"
                 },
                 "msgCall": {
                     "type": "string"
@@ -2160,6 +4499,9 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "migration": {
+                    "$ref": "#/definitions/dto.MigrationResult"
                 },
                 "msgCall": {
                     "type": "string"
@@ -2244,6 +4586,156 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "senderTimestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupDescriptionRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupPictureRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "image"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                },
+                "image": {
+                    "description": "Image can be either a base64-encoded JPEG or a URL pointing to a JPEG.",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupRevokeInviteRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupSendInviteRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "numbers"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "groupJid": {
+                    "type": "string"
+                },
+                "numbers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GroupSubjectRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "subject"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.GroupToggleEphemeralRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "expiration": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        86400,
+                        604800,
+                        7776000
+                    ]
+                },
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupUpdateParticipantRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "groupJid",
+                "participants"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "add",
+                        "remove",
+                        "promote",
+                        "demote"
+                    ]
+                },
+                "groupJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GroupUpdateSettingRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "groupJid"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "announcement",
+                        "not_announcement",
+                        "locked",
+                        "unlocked"
+                    ]
+                },
+                "groupJid": {
                     "type": "string"
                 }
             }
@@ -2343,6 +4835,65 @@ const docTemplate = `{
                 },
                 "remoteJid": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.MigrationBuffer": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.MigrationData": {
+            "type": "object",
+            "required": [
+                "creds"
+            ],
+            "properties": {
+                "creds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "preKeys": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.MigrationPreKey"
+                    }
+                }
+            }
+        },
+        "dto.MigrationPreKey": {
+            "type": "object",
+            "properties": {
+                "keyId": {
+                    "type": "integer"
+                },
+                "private": {
+                    "$ref": "#/definitions/dto.MigrationBuffer"
+                }
+            }
+        },
+        "dto.MigrationResult": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "type": "boolean"
+                },
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                },
+                "preKeysImported": {
+                    "type": "integer"
                 }
             }
         },
@@ -2614,7 +5165,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "reply",
+                        "pix"
+                    ]
                 }
             }
         },
@@ -2654,6 +5209,89 @@ const docTemplate = `{
                 },
                 "type": {
                     "$ref": "#/definitions/dto.SendPresenceRequestType"
+                }
+            }
+        },
+        "dto.SendContactItem": {
+            "type": "object",
+            "required": [
+                "fullName",
+                "phoneNumber"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "fullName": {
+                    "type": "string"
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phoneNumber": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "wuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendContactRequest": {
+            "type": "object",
+            "required": [
+                "contact",
+                "number"
+            ],
+            "properties": {
+                "contact": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendContactItem"
+                    }
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                }
+            }
+        },
+        "dto.SendContactResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -2826,6 +5464,68 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.SendLocationRequest": {
+            "type": "object",
+            "required": [
+                "latitude",
+                "longitude",
+                "number"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                }
+            }
+        },
+        "dto.SendLocationResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendMediaRequest": {
             "type": "object",
             "properties": {
@@ -2867,6 +5567,72 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.SendPollRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "number",
+                "values"
+            ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "selectableCount": {
+                    "type": "integer",
+                    "maximum": 10,
+                    "minimum": 0
+                },
+                "values": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.SendPollResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendPresenceRequestPresence": {
             "type": "string",
             "enum": [
@@ -2889,11 +5655,60 @@ const docTemplate = `{
                 "PresenceTypeAudio"
             ]
         },
-        "dto.SendReactionRequest": {
+        "dto.SendPtvRequest": {
             "type": "object",
             "required": [
-                "reaction"
+                "number",
+                "video"
             ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "video": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendPtvResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendReactionRequest": {
+            "type": "object",
             "properties": {
                 "key": {
                     "type": "object",
@@ -2915,7 +5730,8 @@ const docTemplate = `{
                     }
                 },
                 "reaction": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 10
                 }
             }
         },
@@ -2936,6 +5752,122 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStatusRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "type"
+            ],
+            "properties": {
+                "allContacts": {
+                    "type": "boolean"
+                },
+                "backgroundColor": {
+                    "type": "string"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "font": {
+                    "type": "integer",
+                    "maximum": 5,
+                    "minimum": 0
+                },
+                "statusJidList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "text",
+                        "image",
+                        "audio",
+                        "video"
+                    ]
+                }
+            }
+        },
+        "dto.SendStatusResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStickerRequest": {
+            "type": "object",
+            "required": [
+                "number",
+                "sticker"
+            ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "notConvertSticker": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "sticker": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStickerResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
                     "type": "string"
                 },
                 "status": {
@@ -3082,6 +6014,9 @@ const docTemplate = `{
                         "base64": {
                             "type": "boolean"
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "events": {
                             "type": "array",
                             "items": {
@@ -3188,6 +6123,210 @@ const docTemplate = `{
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "whatsmiau.AcceptGroupInviteResponse": {
+            "type": "object",
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.FindParticipantsResponse": {
+            "type": "object",
+            "properties": {
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
+                }
+            }
+        },
+        "whatsmiau.GroupInfoResponse": {
+            "type": "object",
+            "properties": {
+                "announce": {
+                    "type": "boolean"
+                },
+                "creation": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "descId": {
+                    "type": "string"
+                },
+                "ephemeral": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCommunity": {
+                    "type": "boolean"
+                },
+                "isCommunityAnnounce": {
+                    "type": "boolean"
+                },
+                "joinApprovalMode": {
+                    "type": "boolean"
+                },
+                "linkedParent": {
+                    "type": "string"
+                },
+                "memberAddMode": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
+                },
+                "restrict": {
+                    "type": "boolean"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "subjectOwner": {
+                    "type": "string"
+                },
+                "subjectTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.GroupParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "integer"
+                },
+                "isAdmin": {
+                    "type": "boolean"
+                },
+                "isSuperAdmin": {
+                    "type": "boolean"
+                },
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.InviteCodeResponse": {
+            "type": "object",
+            "properties": {
+                "inviteCode": {
+                    "type": "string"
+                },
+                "inviteUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.LinkedParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.RequestParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                },
+                "requestedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.SendGroupInviteResponse": {
+            "type": "object",
+            "properties": {
+                "inviteUrl": {
+                    "type": "string"
+                },
+                "sent": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.SendInviteResult"
+                    }
+                }
+            }
+        },
+        "whatsmiau.SendInviteResult": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "whatsmiau.SetGroupPictureResponse": {
+            "type": "object",
+            "properties": {
+                "pictureId": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.SubGroupResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "isDefaultSubGroup": {
+                    "type": "boolean"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "subjectTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.UpdateParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -303,6 +303,716 @@
                 }
             }
         },
+        "/group/acceptInviteCode/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Join a group using an invite code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.AcceptGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/create/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create a WhatsApp group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/fetchAllGroups/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List all joined groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Include participants (true/false)",
+                        "name": "getParticipants",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/group/findGroupInfos/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get group info by JID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/inviteCode/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get the group invite code (link)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/inviteInfo/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get info about an invite code (no join)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/leaveGroup/{instance}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Leave a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/participants/{instance}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List participants of a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.FindParticipantsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/revokeInviteCode/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Revoke current invite code and generate a new one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupRevokeInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/sendInvite/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Send group invite link via text to phone numbers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSendInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SendGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/toggleEphemeral/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle disappearing messages for the group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Ephemeral payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupToggleEphemeralRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupDescription/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group description",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Description payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupDescriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupPicture/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group picture",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Picture payload (base64 or URL)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupPictureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SetGroupPictureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateGroupSubject/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group subject (name)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subject payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSubjectRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateParticipant/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group participants (add/remove/promote/demote)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateParticipantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/group/updateSetting/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group setting (announce/locked)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/instance": {
             "get": {
                 "security": [
@@ -1247,6 +1957,1164 @@
                 }
             }
         },
+        "/instance/{instance}/community/create": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Create a WhatsApp community (parent group)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Community payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateCommunityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/createSubGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Create a new group already linked to a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sub group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateCommunitySubGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/linkGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Link an existing group to a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityLinkGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/linkedGroupsParticipants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List participants across all linked groups of a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.LinkedParticipantResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/requestParticipants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List pending join requests",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.RequestParticipantResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/requestParticipants/update": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Approve or reject pending join requests",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityUpdateRequestParticipantsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/setJoinApprovalMode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Toggle join-approval mode for a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunitySetJoinApprovalModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/setMemberAddMode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunitySetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/subGroups": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "List subgroups of a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Community JID",
+                        "name": "communityJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.SubGroupResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/community/unlinkGroup": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Community"
+                ],
+                "summary": "Remove a group from a community",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CommunityLinkGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/acceptInviteCode": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Join a group using an invite code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.AcceptGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/create": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create a WhatsApp group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/fetchAllGroups": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List all joined groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Include participants (true/false)",
+                        "name": "getParticipants",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/findGroupInfos": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get group info by JID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/inviteCode": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get the group invite code (link)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/inviteInfo": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get info about an invite code (no join)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Invite code or full link",
+                        "name": "inviteCode",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.GroupInfoResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/leaveGroup": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Leave a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/participants": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "List participants of a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group JID",
+                        "name": "groupJid",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.FindParticipantsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/revokeInviteCode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Revoke current invite code and generate a new one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupRevokeInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.InviteCodeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/sendInvite": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Send group invite link via text to phone numbers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSendInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SendGroupInviteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/toggleEphemeral": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle disappearing messages for the group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Ephemeral payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupToggleEphemeralRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupDescription": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group description",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Description payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupDescriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupPicture": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group picture",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Picture payload (base64 or URL)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupPictureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.SetGroupPictureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateGroupSubject": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group subject (name)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subject payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSubjectRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateParticipant": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group participants (add/remove/promote/demote)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateParticipantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/whatsmiau.UpdateParticipantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/instance/{instance}/group/updateSetting": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update group setting (announce/locked)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupUpdateSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/instance/{instance}/message/audio": {
             "post": {
                 "security": [
@@ -1631,6 +3499,52 @@
                 }
             }
         },
+        "/instance/{instance}/message/video": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a video file by URL to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a video",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Video parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendDocumentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendDocumentResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendButtons/{instance}": {
             "post": {
                 "security": [
@@ -1690,6 +3604,52 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendContact/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends contact cards (vCard) to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send one or more contacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Contact parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendContactResponse"
                         }
                     }
                 }
@@ -1759,6 +3719,52 @@
                 }
             }
         },
+        "/message/sendLocation/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a geographic location to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a location message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendLocationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendLocationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendMedia/{instance}": {
             "post": {
                 "security": [
@@ -1823,6 +3829,98 @@
                 }
             }
         },
+        "/message/sendPoll/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a multiple-choice poll to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a poll",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Poll parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPollRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPollResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendPtv/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a round/circle video note to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a round video note (PTV)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "PTV parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPtvRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendPtvResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/message/sendReaction/{instance}": {
             "post": {
                 "security": [
@@ -1882,6 +3980,98 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendStatus/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a status (text/image/audio/video) to status@broadcast",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a status broadcast",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStatusResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/message/sendSticker/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Sends a WebP sticker to a WhatsApp number",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Send a sticker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sticker parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStickerRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SendStickerResponse"
                         }
                     }
                 }
@@ -2017,6 +4207,81 @@
         }
     },
     "definitions": {
+        "dto.CommunityLinkGroupRequest": {
+            "type": "object",
+            "required": [
+                "childJid",
+                "parentJid"
+            ],
+            "properties": {
+                "childJid": {
+                    "type": "string"
+                },
+                "parentJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CommunitySetJoinApprovalModeRequest": {
+            "type": "object",
+            "required": [
+                "communityJid"
+            ],
+            "properties": {
+                "communityJid": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.CommunitySetMemberAddModeRequest": {
+            "type": "object",
+            "required": [
+                "communityJid",
+                "mode"
+            ],
+            "properties": {
+                "communityJid": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "admin_add",
+                        "all_member_add"
+                    ]
+                }
+            }
+        },
+        "dto.CommunityUpdateRequestParticipantsRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "communityJid",
+                "participants"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "approve",
+                        "reject"
+                    ]
+                },
+                "communityJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "dto.ConnectInstanceResponse": {
             "type": "object",
             "properties": {
@@ -2039,6 +4304,9 @@
                     "type": "string"
                 },
                 "msgCall": {
+                    "type": "string"
+                },
+                "pairingCode": {
                     "type": "string"
                 },
                 "proxyHost": {
@@ -2087,6 +4355,74 @@
                 }
             }
         },
+        "dto.CreateCommunityRequest": {
+            "type": "object",
+            "required": [
+                "subject"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.CreateCommunitySubGroupRequest": {
+            "type": "object",
+            "required": [
+                "parentJid",
+                "participants",
+                "subject"
+            ],
+            "properties": {
+                "parentJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.CreateGroupRequest": {
+            "type": "object",
+            "required": [
+                "participants",
+                "subject"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "promoteParticipants": {
+                    "type": "boolean"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
         "dto.CreateInstanceRequest": {
             "type": "object",
             "properties": {
@@ -2101,6 +4437,9 @@
                 },
                 "instanceName": {
                     "type": "string"
+                },
+                "migration": {
+                    "$ref": "#/definitions/dto.MigrationData"
                 },
                 "msgCall": {
                     "type": "string"
@@ -2154,6 +4493,9 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "migration": {
+                    "$ref": "#/definitions/dto.MigrationResult"
                 },
                 "msgCall": {
                     "type": "string"
@@ -2238,6 +4580,156 @@
                     "type": "string"
                 },
                 "senderTimestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupDescriptionRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupPictureRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "image"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                },
+                "image": {
+                    "description": "Image can be either a base64-encoded JPEG or a URL pointing to a JPEG.",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupRevokeInviteRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupSendInviteRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "numbers"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "groupJid": {
+                    "type": "string"
+                },
+                "numbers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GroupSubjectRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "subject"
+            ],
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string",
+                    "maxLength": 25,
+                    "minLength": 1
+                }
+            }
+        },
+        "dto.GroupToggleEphemeralRequest": {
+            "type": "object",
+            "required": [
+                "groupJid"
+            ],
+            "properties": {
+                "expiration": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        86400,
+                        604800,
+                        7776000
+                    ]
+                },
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.GroupUpdateParticipantRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "groupJid",
+                "participants"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "add",
+                        "remove",
+                        "promote",
+                        "demote"
+                    ]
+                },
+                "groupJid": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GroupUpdateSettingRequest": {
+            "type": "object",
+            "required": [
+                "action",
+                "groupJid"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "announcement",
+                        "not_announcement",
+                        "locked",
+                        "unlocked"
+                    ]
+                },
+                "groupJid": {
                     "type": "string"
                 }
             }
@@ -2337,6 +4829,65 @@
                 },
                 "remoteJid": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.MigrationBuffer": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.MigrationData": {
+            "type": "object",
+            "required": [
+                "creds"
+            ],
+            "properties": {
+                "creds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "preKeys": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.MigrationPreKey"
+                    }
+                }
+            }
+        },
+        "dto.MigrationPreKey": {
+            "type": "object",
+            "properties": {
+                "keyId": {
+                    "type": "integer"
+                },
+                "private": {
+                    "$ref": "#/definitions/dto.MigrationBuffer"
+                }
+            }
+        },
+        "dto.MigrationResult": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "type": "boolean"
+                },
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                },
+                "preKeysImported": {
+                    "type": "integer"
                 }
             }
         },
@@ -2608,7 +5159,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "reply",
+                        "pix"
+                    ]
                 }
             }
         },
@@ -2648,6 +5203,89 @@
                 },
                 "type": {
                     "$ref": "#/definitions/dto.SendPresenceRequestType"
+                }
+            }
+        },
+        "dto.SendContactItem": {
+            "type": "object",
+            "required": [
+                "fullName",
+                "phoneNumber"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "fullName": {
+                    "type": "string"
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phoneNumber": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "wuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendContactRequest": {
+            "type": "object",
+            "required": [
+                "contact",
+                "number"
+            ],
+            "properties": {
+                "contact": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/dto.SendContactItem"
+                    }
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                }
+            }
+        },
+        "dto.SendContactResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -2820,6 +5458,68 @@
                 }
             }
         },
+        "dto.SendLocationRequest": {
+            "type": "object",
+            "required": [
+                "latitude",
+                "longitude",
+                "number"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                }
+            }
+        },
+        "dto.SendLocationResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendMediaRequest": {
             "type": "object",
             "properties": {
@@ -2861,6 +5561,72 @@
                 }
             }
         },
+        "dto.SendPollRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "number",
+                "values"
+            ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "selectableCount": {
+                    "type": "integer",
+                    "maximum": 10,
+                    "minimum": 0
+                },
+                "values": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "minItems": 2,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.SendPollResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.SendPresenceRequestPresence": {
             "type": "string",
             "enum": [
@@ -2883,11 +5649,60 @@
                 "PresenceTypeAudio"
             ]
         },
-        "dto.SendReactionRequest": {
+        "dto.SendPtvRequest": {
             "type": "object",
             "required": [
-                "reaction"
+                "number",
+                "video"
             ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "video": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendPtvResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendReactionRequest": {
+            "type": "object",
             "properties": {
                 "key": {
                     "type": "object",
@@ -2909,7 +5724,8 @@
                     }
                 },
                 "reaction": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 10
                 }
             }
         },
@@ -2930,6 +5746,122 @@
                     "type": "string"
                 },
                 "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStatusRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "type"
+            ],
+            "properties": {
+                "allContacts": {
+                    "type": "boolean"
+                },
+                "backgroundColor": {
+                    "type": "string"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "font": {
+                    "type": "integer",
+                    "maximum": 5,
+                    "minimum": 0
+                },
+                "statusJidList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "text",
+                        "image",
+                        "audio",
+                        "video"
+                    ]
+                }
+            }
+        },
+        "dto.SendStatusResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStickerRequest": {
+            "type": "object",
+            "required": [
+                "number",
+                "sticker"
+            ],
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "maximum": 300000,
+                    "minimum": 0
+                },
+                "mentioned": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mentionsEveryOne": {
+                    "type": "boolean"
+                },
+                "notConvertSticker": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "quoted": {
+                    "$ref": "#/definitions/dto.MessageRequestQuoted"
+                },
+                "sticker": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.SendStickerResponse": {
+            "type": "object",
+            "properties": {
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/dto.MessageResponseKey"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
                     "type": "string"
                 },
                 "status": {
@@ -3076,6 +6008,9 @@
                         "base64": {
                             "type": "boolean"
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "events": {
                             "type": "array",
                             "items": {
@@ -3182,6 +6117,210 @@
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "whatsmiau.AcceptGroupInviteResponse": {
+            "type": "object",
+            "properties": {
+                "groupJid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.FindParticipantsResponse": {
+            "type": "object",
+            "properties": {
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
+                }
+            }
+        },
+        "whatsmiau.GroupInfoResponse": {
+            "type": "object",
+            "properties": {
+                "announce": {
+                    "type": "boolean"
+                },
+                "creation": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "descId": {
+                    "type": "string"
+                },
+                "ephemeral": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCommunity": {
+                    "type": "boolean"
+                },
+                "isCommunityAnnounce": {
+                    "type": "boolean"
+                },
+                "joinApprovalMode": {
+                    "type": "boolean"
+                },
+                "linkedParent": {
+                    "type": "string"
+                },
+                "memberAddMode": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
+                },
+                "restrict": {
+                    "type": "boolean"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "subjectOwner": {
+                    "type": "string"
+                },
+                "subjectTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.GroupParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "integer"
+                },
+                "isAdmin": {
+                    "type": "boolean"
+                },
+                "isSuperAdmin": {
+                    "type": "boolean"
+                },
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.InviteCodeResponse": {
+            "type": "object",
+            "properties": {
+                "inviteCode": {
+                    "type": "string"
+                },
+                "inviteUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.LinkedParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.RequestParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "jid": {
+                    "type": "string"
+                },
+                "lid": {
+                    "type": "string"
+                },
+                "requestedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.SendGroupInviteResponse": {
+            "type": "object",
+            "properties": {
+                "inviteUrl": {
+                    "type": "string"
+                },
+                "sent": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.SendInviteResult"
+                    }
+                }
+            }
+        },
+        "whatsmiau.SendInviteResult": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "whatsmiau.SetGroupPictureResponse": {
+            "type": "object",
+            "properties": {
+                "pictureId": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.SubGroupResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "isDefaultSubGroup": {
+                    "type": "boolean"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "subjectTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.UpdateParticipantResponse": {
+            "type": "object",
+            "properties": {
+                "participants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
+                    }
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,56 @@
 basePath: /v1
 definitions:
+  dto.CommunityLinkGroupRequest:
+    properties:
+      childJid:
+        type: string
+      parentJid:
+        type: string
+    required:
+    - childJid
+    - parentJid
+    type: object
+  dto.CommunitySetJoinApprovalModeRequest:
+    properties:
+      communityJid:
+        type: string
+      mode:
+        type: boolean
+    required:
+    - communityJid
+    type: object
+  dto.CommunitySetMemberAddModeRequest:
+    properties:
+      communityJid:
+        type: string
+      mode:
+        enum:
+        - admin_add
+        - all_member_add
+        type: string
+    required:
+    - communityJid
+    - mode
+    type: object
+  dto.CommunityUpdateRequestParticipantsRequest:
+    properties:
+      action:
+        enum:
+        - approve
+        - reject
+        type: string
+      communityJid:
+        type: string
+      participants:
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - action
+    - communityJid
+    - participants
+    type: object
   dto.ConnectInstanceResponse:
     properties:
       alwaysOnline:
@@ -15,6 +66,8 @@ definitions:
       message:
         type: string
       msgCall:
+        type: string
+      pairingCode:
         type: string
       proxyHost:
         type: string
@@ -46,6 +99,54 @@ definitions:
       conversation:
         type: string
     type: object
+  dto.CreateCommunityRequest:
+    properties:
+      description:
+        type: string
+      subject:
+        maxLength: 25
+        minLength: 1
+        type: string
+    required:
+    - subject
+    type: object
+  dto.CreateCommunitySubGroupRequest:
+    properties:
+      parentJid:
+        type: string
+      participants:
+        items:
+          type: string
+        minItems: 1
+        type: array
+      subject:
+        maxLength: 25
+        minLength: 1
+        type: string
+    required:
+    - parentJid
+    - participants
+    - subject
+    type: object
+  dto.CreateGroupRequest:
+    properties:
+      description:
+        type: string
+      participants:
+        items:
+          type: string
+        minItems: 1
+        type: array
+      promoteParticipants:
+        type: boolean
+      subject:
+        maxLength: 25
+        minLength: 1
+        type: string
+    required:
+    - participants
+    - subject
+    type: object
   dto.CreateInstanceRequest:
     properties:
       alwaysOnline:
@@ -56,6 +157,8 @@ definitions:
         type: string
       instanceName:
         type: string
+      migration:
+        $ref: '#/definitions/dto.MigrationData'
       msgCall:
         type: string
       proxyHost:
@@ -91,6 +194,8 @@ definitions:
         type: boolean
       id:
         type: string
+      migration:
+        $ref: '#/definitions/dto.MigrationResult'
       msgCall:
         type: string
       proxyHost:
@@ -147,6 +252,111 @@ definitions:
         type: string
       senderTimestamp:
         type: string
+    type: object
+  dto.GroupDescriptionRequest:
+    properties:
+      description:
+        type: string
+      groupJid:
+        type: string
+    required:
+    - groupJid
+    type: object
+  dto.GroupPictureRequest:
+    properties:
+      groupJid:
+        type: string
+      image:
+        description: Image can be either a base64-encoded JPEG or a URL pointing to
+          a JPEG.
+        type: string
+    required:
+    - groupJid
+    - image
+    type: object
+  dto.GroupRevokeInviteRequest:
+    properties:
+      groupJid:
+        type: string
+    required:
+    - groupJid
+    type: object
+  dto.GroupSendInviteRequest:
+    properties:
+      description:
+        type: string
+      groupJid:
+        type: string
+      numbers:
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - groupJid
+    - numbers
+    type: object
+  dto.GroupSubjectRequest:
+    properties:
+      groupJid:
+        type: string
+      subject:
+        maxLength: 25
+        minLength: 1
+        type: string
+    required:
+    - groupJid
+    - subject
+    type: object
+  dto.GroupToggleEphemeralRequest:
+    properties:
+      expiration:
+        enum:
+        - 0
+        - 86400
+        - 604800
+        - 7776000
+        type: integer
+      groupJid:
+        type: string
+    required:
+    - groupJid
+    type: object
+  dto.GroupUpdateParticipantRequest:
+    properties:
+      action:
+        enum:
+        - add
+        - remove
+        - promote
+        - demote
+        type: string
+      groupJid:
+        type: string
+      participants:
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - action
+    - groupJid
+    - participants
+    type: object
+  dto.GroupUpdateSettingRequest:
+    properties:
+      action:
+        enum:
+        - announcement
+        - not_announcement
+        - locked
+        - unlocked
+        type: string
+      groupJid:
+        type: string
+    required:
+    - action
+    - groupJid
     type: object
   dto.ListInstancesResponse:
     properties:
@@ -211,6 +421,44 @@ definitions:
         type: string
       remoteJid:
         type: string
+    type: object
+  dto.MigrationBuffer:
+    properties:
+      data:
+        type: string
+      type:
+        type: string
+    type: object
+  dto.MigrationData:
+    properties:
+      creds:
+        items:
+          type: integer
+        type: array
+      preKeys:
+        items:
+          $ref: '#/definitions/dto.MigrationPreKey'
+        type: array
+    required:
+    - creds
+    type: object
+  dto.MigrationPreKey:
+    properties:
+      keyId:
+        type: integer
+      private:
+        $ref: '#/definitions/dto.MigrationBuffer'
+    type: object
+  dto.MigrationResult:
+    properties:
+      connected:
+        type: boolean
+      jid:
+        type: string
+      lid:
+        type: string
+      preKeysImported:
+        type: integer
     type: object
   dto.NumberExistsRequest:
     properties:
@@ -392,6 +640,9 @@ definitions:
       name:
         type: string
       type:
+        enum:
+        - reply
+        - pix
         type: string
     required:
     - displayText
@@ -422,6 +673,62 @@ definitions:
         $ref: '#/definitions/dto.SendPresenceRequestPresence'
       type:
         $ref: '#/definitions/dto.SendPresenceRequestType'
+    type: object
+  dto.SendContactItem:
+    properties:
+      email:
+        type: string
+      fullName:
+        type: string
+      organization:
+        type: string
+      phoneNumber:
+        type: string
+      url:
+        type: string
+      wuid:
+        type: string
+    required:
+    - fullName
+    - phoneNumber
+    type: object
+  dto.SendContactRequest:
+    properties:
+      contact:
+        items:
+          $ref: '#/definitions/dto.SendContactItem'
+        minItems: 1
+        type: array
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      mentioned:
+        items:
+          type: string
+        type: array
+      mentionsEveryOne:
+        type: boolean
+      number:
+        type: string
+      quoted:
+        $ref: '#/definitions/dto.MessageRequestQuoted'
+    required:
+    - contact
+    - number
+    type: object
+  dto.SendContactResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
     type: object
   dto.SendDocumentRequest:
     properties:
@@ -537,6 +844,48 @@ definitions:
       status:
         type: string
     type: object
+  dto.SendLocationRequest:
+    properties:
+      address:
+        type: string
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      latitude:
+        type: number
+      longitude:
+        type: number
+      mentioned:
+        items:
+          type: string
+        type: array
+      mentionsEveryOne:
+        type: boolean
+      name:
+        type: string
+      number:
+        type: string
+      quoted:
+        $ref: '#/definitions/dto.MessageRequestQuoted'
+    required:
+    - latitude
+    - longitude
+    - number
+    type: object
+  dto.SendLocationResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
+    type: object
   dto.SendMediaRequest:
     properties:
       caption:
@@ -565,6 +914,52 @@ definitions:
       quoted:
         $ref: '#/definitions/dto.MessageRequestQuoted'
     type: object
+  dto.SendPollRequest:
+    properties:
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      mentioned:
+        items:
+          type: string
+        type: array
+      mentionsEveryOne:
+        type: boolean
+      name:
+        type: string
+      number:
+        type: string
+      quoted:
+        $ref: '#/definitions/dto.MessageRequestQuoted'
+      selectableCount:
+        maximum: 10
+        minimum: 0
+        type: integer
+      values:
+        items:
+          type: string
+        maxItems: 10
+        minItems: 2
+        type: array
+    required:
+    - name
+    - number
+    - values
+    type: object
+  dto.SendPollResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
+    type: object
   dto.SendPresenceRequestPresence:
     enum:
     - composing
@@ -581,6 +976,41 @@ definitions:
     x-enum-varnames:
     - PresenceTypeText
     - PresenceTypeAudio
+  dto.SendPtvRequest:
+    properties:
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      mentioned:
+        items:
+          type: string
+        type: array
+      mentionsEveryOne:
+        type: boolean
+      number:
+        type: string
+      quoted:
+        $ref: '#/definitions/dto.MessageRequestQuoted'
+      video:
+        type: string
+    required:
+    - number
+    - video
+    type: object
+  dto.SendPtvResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
+    type: object
   dto.SendReactionRequest:
     properties:
       key:
@@ -597,9 +1027,8 @@ definitions:
         - remoteJid
         type: object
       reaction:
+        maxLength: 10
         type: string
-    required:
-    - reaction
     type: object
   dto.SendReactionResponse:
     properties:
@@ -613,6 +1042,85 @@ definitions:
       messageType:
         type: string
       source:
+        type: string
+      status:
+        type: string
+    type: object
+  dto.SendStatusRequest:
+    properties:
+      allContacts:
+        type: boolean
+      backgroundColor:
+        type: string
+      caption:
+        type: string
+      content:
+        type: string
+      font:
+        maximum: 5
+        minimum: 0
+        type: integer
+      statusJidList:
+        items:
+          type: string
+        type: array
+      type:
+        enum:
+        - text
+        - image
+        - audio
+        - video
+        type: string
+    required:
+    - content
+    - type
+    type: object
+  dto.SendStatusResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      status:
+        type: string
+    type: object
+  dto.SendStickerRequest:
+    properties:
+      delay:
+        maximum: 300000
+        minimum: 0
+        type: integer
+      mentioned:
+        items:
+          type: string
+        type: array
+      mentionsEveryOne:
+        type: boolean
+      notConvertSticker:
+        type: boolean
+      number:
+        type: string
+      quoted:
+        $ref: '#/definitions/dto.MessageRequestQuoted'
+      sticker:
+        type: string
+    required:
+    - number
+    - sticker
+    type: object
+  dto.SendStickerResponse:
+    properties:
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/dto.MessageResponseKey'
+      messageTimestamp:
+        type: integer
+      messageType:
         type: string
       status:
         type: string
@@ -709,6 +1217,8 @@ definitions:
         properties:
           base64:
             type: boolean
+          enabled:
+            type: boolean
           events:
             items:
               type: string
@@ -779,6 +1289,138 @@ definitions:
         type: string
       message:
         type: string
+    type: object
+  whatsmiau.AcceptGroupInviteResponse:
+    properties:
+      groupJid:
+        type: string
+    type: object
+  whatsmiau.FindParticipantsResponse:
+    properties:
+      participants:
+        items:
+          $ref: '#/definitions/whatsmiau.GroupParticipantResponse'
+        type: array
+    type: object
+  whatsmiau.GroupInfoResponse:
+    properties:
+      announce:
+        type: boolean
+      creation:
+        type: integer
+      desc:
+        type: string
+      descId:
+        type: string
+      ephemeral:
+        type: integer
+      id:
+        type: string
+      isCommunity:
+        type: boolean
+      isCommunityAnnounce:
+        type: boolean
+      joinApprovalMode:
+        type: boolean
+      linkedParent:
+        type: string
+      memberAddMode:
+        type: string
+      owner:
+        type: string
+      participants:
+        items:
+          $ref: '#/definitions/whatsmiau.GroupParticipantResponse'
+        type: array
+      restrict:
+        type: boolean
+      size:
+        type: integer
+      subject:
+        type: string
+      subjectOwner:
+        type: string
+      subjectTime:
+        type: integer
+    type: object
+  whatsmiau.GroupParticipantResponse:
+    properties:
+      displayName:
+        type: string
+      error:
+        type: integer
+      isAdmin:
+        type: boolean
+      isSuperAdmin:
+        type: boolean
+      jid:
+        type: string
+      lid:
+        type: string
+    type: object
+  whatsmiau.InviteCodeResponse:
+    properties:
+      inviteCode:
+        type: string
+      inviteUrl:
+        type: string
+    type: object
+  whatsmiau.LinkedParticipantResponse:
+    properties:
+      jid:
+        type: string
+      lid:
+        type: string
+    type: object
+  whatsmiau.RequestParticipantResponse:
+    properties:
+      jid:
+        type: string
+      lid:
+        type: string
+      requestedAt:
+        type: integer
+    type: object
+  whatsmiau.SendGroupInviteResponse:
+    properties:
+      inviteUrl:
+        type: string
+      sent:
+        items:
+          $ref: '#/definitions/whatsmiau.SendInviteResult'
+        type: array
+    type: object
+  whatsmiau.SendInviteResult:
+    properties:
+      error:
+        type: string
+      number:
+        type: string
+      success:
+        type: boolean
+    type: object
+  whatsmiau.SetGroupPictureResponse:
+    properties:
+      pictureId:
+        type: string
+    type: object
+  whatsmiau.SubGroupResponse:
+    properties:
+      id:
+        type: string
+      isDefaultSubGroup:
+        type: boolean
+      subject:
+        type: string
+      subjectTime:
+        type: integer
+    type: object
+  whatsmiau.UpdateParticipantResponse:
+    properties:
+      participants:
+        items:
+          $ref: '#/definitions/whatsmiau.GroupParticipantResponse'
+        type: array
     type: object
 host: localhost:8080
 info:
@@ -979,6 +1621,451 @@ paths:
       summary: Check if numbers exist on WhatsApp
       tags:
       - Chat
+  /group/acceptInviteCode/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite code or full link
+        in: query
+        name: inviteCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.AcceptGroupInviteResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Join a group using an invite code
+      tags:
+      - Group
+  /group/create/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreateGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create a WhatsApp group
+      tags:
+      - Group
+  /group/fetchAllGroups/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Include participants (true/false)
+        in: query
+        name: getParticipants
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: List all joined groups
+      tags:
+      - Group
+  /group/findGroupInfos/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get group info by JID
+      tags:
+      - Group
+  /group/inviteCode/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.InviteCodeResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get the group invite code (link)
+      tags:
+      - Group
+  /group/inviteInfo/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite code or full link
+        in: query
+        name: inviteCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get info about an invite code (no join)
+      tags:
+      - Group
+  /group/leaveGroup/{instance}:
+    delete:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Leave a group
+      tags:
+      - Group
+  /group/participants/{instance}:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.FindParticipantsResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List participants of a group
+      tags:
+      - Group
+  /group/revokeInviteCode/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupRevokeInviteRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.InviteCodeResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Revoke current invite code and generate a new one
+      tags:
+      - Group
+  /group/sendInvite/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSendInviteRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.SendGroupInviteResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send group invite link via text to phone numbers
+      tags:
+      - Group
+  /group/toggleEphemeral/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Ephemeral payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupToggleEphemeralRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle disappearing messages for the group
+      tags:
+      - Group
+  /group/updateGroupDescription/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Description payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupDescriptionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group description
+      tags:
+      - Group
+  /group/updateGroupPicture/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Picture payload (base64 or URL)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupPictureRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.SetGroupPictureResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update group picture
+      tags:
+      - Group
+  /group/updateGroupSubject/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Subject payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSubjectRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group subject (name)
+      tags:
+      - Group
+  /group/updateParticipant/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupUpdateParticipantRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.UpdateParticipantResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update group participants (add/remove/promote/demote)
+      tags:
+      - Group
+  /group/updateSetting/{instance}:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Setting payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupUpdateSettingRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group setting (announce/locked)
+      tags:
+      - Group
   /instance:
     get:
       description: Returns all instances, optionally filtered by name or ID
@@ -1306,6 +2393,732 @@ paths:
       summary: Mark messages as read
       tags:
       - Chat
+  /instance/{instance}/community/create:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Community payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreateCommunityRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create a WhatsApp community (parent group)
+      tags:
+      - Community
+  /instance/{instance}/community/createSubGroup:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Sub group payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreateCommunitySubGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create a new group already linked to a community
+      tags:
+      - Community
+  /instance/{instance}/community/linkGroup:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Link payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CommunityLinkGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Link an existing group to a community
+      tags:
+      - Community
+  /instance/{instance}/community/linkedGroupsParticipants:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Community JID
+        in: query
+        name: communityJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.LinkedParticipantResponse'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: List participants across all linked groups of a community
+      tags:
+      - Community
+  /instance/{instance}/community/requestParticipants:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Community JID
+        in: query
+        name: communityJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.RequestParticipantResponse'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: List pending join requests
+      tags:
+      - Community
+  /instance/{instance}/community/requestParticipants/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CommunityUpdateRequestParticipantsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.UpdateParticipantResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Approve or reject pending join requests
+      tags:
+      - Community
+  /instance/{instance}/community/setJoinApprovalMode:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Mode payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CommunitySetJoinApprovalModeRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle join-approval mode for a community
+      tags:
+      - Community
+  /instance/{instance}/community/setMemberAddMode:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Mode payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CommunitySetMemberAddModeRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle who can add members (admins only or all)
+      tags:
+      - Community
+  /instance/{instance}/community/subGroups:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Community JID
+        in: query
+        name: communityJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.SubGroupResponse'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: List subgroups of a community
+      tags:
+      - Community
+  /instance/{instance}/community/unlinkGroup:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Unlink payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CommunityLinkGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Remove a group from a community
+      tags:
+      - Community
+  /instance/{instance}/group/acceptInviteCode:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite code or full link
+        in: query
+        name: inviteCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.AcceptGroupInviteResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Join a group using an invite code
+      tags:
+      - Group
+  /instance/{instance}/group/create:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreateGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Create a WhatsApp group
+      tags:
+      - Group
+  /instance/{instance}/group/fetchAllGroups:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Include participants (true/false)
+        in: query
+        name: getParticipants
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: List all joined groups
+      tags:
+      - Group
+  /instance/{instance}/group/findGroupInfos:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get group info by JID
+      tags:
+      - Group
+  /instance/{instance}/group/inviteCode:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.InviteCodeResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get the group invite code (link)
+      tags:
+      - Group
+  /instance/{instance}/group/inviteInfo:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite code or full link
+        in: query
+        name: inviteCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.GroupInfoResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get info about an invite code (no join)
+      tags:
+      - Group
+  /instance/{instance}/group/leaveGroup:
+    delete:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Leave a group
+      tags:
+      - Group
+  /instance/{instance}/group/participants:
+    get:
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group JID
+        in: query
+        name: groupJid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.FindParticipantsResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List participants of a group
+      tags:
+      - Group
+  /instance/{instance}/group/revokeInviteCode:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Group payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupRevokeInviteRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.InviteCodeResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Revoke current invite code and generate a new one
+      tags:
+      - Group
+  /instance/{instance}/group/sendInvite:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Invite payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSendInviteRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/whatsmiau.SendGroupInviteResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send group invite link via text to phone numbers
+      tags:
+      - Group
+  /instance/{instance}/group/toggleEphemeral:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Ephemeral payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupToggleEphemeralRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle disappearing messages for the group
+      tags:
+      - Group
+  /instance/{instance}/group/updateGroupDescription:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Description payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupDescriptionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group description
+      tags:
+      - Group
+  /instance/{instance}/group/updateGroupPicture:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Picture payload (base64 or URL)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupPictureRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.SetGroupPictureResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update group picture
+      tags:
+      - Group
+  /instance/{instance}/group/updateGroupSubject:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Subject payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSubjectRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group subject (name)
+      tags:
+      - Group
+  /instance/{instance}/group/updateParticipant:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupUpdateParticipantRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/whatsmiau.UpdateParticipantResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update group participants (add/remove/promote/demote)
+      tags:
+      - Group
+  /instance/{instance}/group/updateSetting:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Setting payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupUpdateSettingRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update group setting (announce/locked)
+      tags:
+      - Group
   /instance/{instance}/message/audio:
     post:
       consumes:
@@ -1551,6 +3364,35 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send a text message
+      tags:
+      - Message
+  /instance/{instance}/message/video:
+    post:
+      consumes:
+      - application/json
+      description: Sends a video file by URL to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Video parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendDocumentRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendDocumentResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a video
       tags:
       - Message
   /instance/connect/{id}:
@@ -1876,6 +3718,35 @@ paths:
       summary: Send a buttons message
       tags:
       - Message
+  /message/sendContact/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends contact cards (vCard) to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Contact parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendContactRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendContactResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send one or more contacts
+      tags:
+      - Message
   /message/sendList/{instance}:
     post:
       consumes:
@@ -1915,6 +3786,35 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send a list message
+      tags:
+      - Message
+  /message/sendLocation/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends a geographic location to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Location parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendLocationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendLocationResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a location message
       tags:
       - Message
   /message/sendMedia/{instance}:
@@ -1958,6 +3858,64 @@ paths:
       summary: Send a media message (Evolution API)
       tags:
       - Message
+  /message/sendPoll/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends a multiple-choice poll to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Poll parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendPollRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendPollResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a poll
+      tags:
+      - Message
+  /message/sendPtv/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends a round/circle video note to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: PTV parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendPtvRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendPtvResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a round video note (PTV)
+      tags:
+      - Message
   /message/sendReaction/{instance}:
     post:
       consumes:
@@ -1998,6 +3956,64 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send a reaction to a message
+      tags:
+      - Message
+  /message/sendStatus/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends a status (text/image/audio/video) to status@broadcast
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Status parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendStatusResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a status broadcast
+      tags:
+      - Message
+  /message/sendSticker/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Sends a WebP sticker to a WhatsApp number
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Sticker parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SendStickerRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SendStickerResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Send a sticker
       tags:
       - Message
   /message/sendText/{instance}:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/puzpuzpuz/xsync/v4 v4.1.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/echo-swagger v1.5.2
 	github.com/swaggo/swag v1.16.6
 	go.mau.fi/whatsmeow v0.0.0-20260210142427-8e7b838d2481
@@ -45,6 +46,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/elliotchance/orderedmap/v3 v3.1.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/zerolog v1.35.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/sv-tools/openapi v0.2.1 // indirect

--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -1,0 +1,897 @@
+package whatsmiau
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.uber.org/zap"
+)
+
+// ---------- Shared response shapes ----------
+
+type GroupParticipantResponse struct {
+	Jid          string `json:"jid"`
+	Lid          string `json:"lid"`
+	IsAdmin      bool   `json:"isAdmin"`
+	IsSuperAdmin bool   `json:"isSuperAdmin"`
+	DisplayName  string `json:"displayName,omitempty"`
+	Error        int    `json:"error,omitempty"`
+}
+
+type GroupInfoResponse struct {
+	Id                  string                     `json:"id"`
+	Subject             string                     `json:"subject"`
+	SubjectOwner        string                     `json:"subjectOwner,omitempty"`
+	SubjectTime         int64                      `json:"subjectTime,omitempty"`
+	Size                int                        `json:"size"`
+	Creation            int64                      `json:"creation,omitempty"`
+	Owner               string                     `json:"owner,omitempty"`
+	Desc                string                     `json:"desc,omitempty"`
+	DescId              string                     `json:"descId,omitempty"`
+	Restrict            bool                       `json:"restrict"`
+	Announce            bool                       `json:"announce"`
+	IsCommunity         bool                       `json:"isCommunity"`
+	IsCommunityAnnounce bool                       `json:"isCommunityAnnounce"`
+	LinkedParent        string                     `json:"linkedParent,omitempty"`
+	MemberAddMode       string                     `json:"memberAddMode,omitempty"`
+	JoinApprovalMode    bool                       `json:"joinApprovalMode"`
+	Ephemeral           uint32                     `json:"ephemeral,omitempty"`
+	Participants        []GroupParticipantResponse `json:"participants,omitempty"`
+}
+
+func (s *Whatsmiau) buildGroupInfoResponse(ctx context.Context, instanceID string, g *types.GroupInfo, withParticipants bool) GroupInfoResponse {
+	ownerJid, _ := s.GetJidLid(ctx, instanceID, g.OwnerJID)
+	subjectOwnerJid, _ := s.GetJidLid(ctx, instanceID, g.NameSetBy)
+
+	resp := GroupInfoResponse{
+		Id:                  g.JID.String(),
+		Subject:             g.Name,
+		SubjectOwner:        subjectOwnerJid,
+		SubjectTime:         g.NameSetAt.Unix(),
+		Size:                g.ParticipantCount,
+		Creation:            g.GroupCreated.Unix(),
+		Owner:               ownerJid,
+		Desc:                g.Topic,
+		DescId:              g.TopicID,
+		Restrict:            g.IsLocked,
+		Announce:            g.IsAnnounce,
+		IsCommunity:         g.IsParent,
+		IsCommunityAnnounce: g.IsDefaultSubGroup && g.IsAnnounce,
+		MemberAddMode:       string(g.MemberAddMode),
+		JoinApprovalMode:    g.IsJoinApprovalRequired,
+		Ephemeral:           g.DisappearingTimer,
+	}
+	if !g.LinkedParentJID.IsEmpty() {
+		resp.LinkedParent = g.LinkedParentJID.String()
+	}
+	if g.ParticipantCount == 0 {
+		resp.Size = len(g.Participants)
+	}
+	if withParticipants {
+		resp.Participants = s.mapParticipants(ctx, instanceID, g.Participants)
+	}
+	return resp
+}
+
+func (s *Whatsmiau) mapParticipants(ctx context.Context, instanceID string, participants []types.GroupParticipant) []GroupParticipantResponse {
+	out := make([]GroupParticipantResponse, 0, len(participants))
+	for _, p := range participants {
+		jid, lid := s.GetJidLid(ctx, instanceID, p.JID)
+		out = append(out, GroupParticipantResponse{
+			Jid:          jid,
+			Lid:          lid,
+			IsAdmin:      p.IsAdmin,
+			IsSuperAdmin: p.IsSuperAdmin,
+			DisplayName:  p.DisplayName,
+			Error:        p.Error,
+		})
+	}
+	return out
+}
+
+// ---------- CreateGroup ----------
+
+type CreateGroupRequest struct {
+	InstanceID          string
+	Subject             string
+	Description         string
+	Participants        []string
+	PromoteParticipants bool
+}
+
+func (s *Whatsmiau) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	participantJids, err := s.numbersToJIDs(ctx, client, req.Participants, true)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := client.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
+		Name:         req.Subject,
+		Participants: participantJids,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create group: %w", err)
+	}
+
+	if req.Description != "" {
+		if err := client.SetGroupDescription(ctx, created.JID, req.Description); err != nil {
+			zap.L().Warn("group created but failed to set description", zap.Error(err), zap.String("group", created.JID.String()))
+		}
+	}
+
+	if req.PromoteParticipants && len(participantJids) > 0 {
+		if _, err := client.UpdateGroupParticipants(ctx, created.JID, participantJids, whatsmeow.ParticipantChangePromote); err != nil {
+			zap.L().Warn("group created but failed to promote participants", zap.Error(err), zap.String("group", created.JID.String()))
+		}
+	}
+
+	info, err := client.GetGroupInfo(ctx, created.JID)
+	if err != nil {
+		resp := s.buildGroupInfoResponse(ctx, req.InstanceID, created, true)
+		return &resp, nil
+	}
+	resp := s.buildGroupInfoResponse(ctx, req.InstanceID, info, true)
+	return &resp, nil
+}
+
+// ---------- SetGroupSubject ----------
+
+type SetGroupSubjectRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+	Subject    string
+}
+
+func (s *Whatsmiau) SetGroupSubject(ctx context.Context, req *SetGroupSubjectRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	return client.SetGroupName(ctx, *req.GroupJID, req.Subject)
+}
+
+// ---------- SetGroupPicture ----------
+
+type SetGroupPictureRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+	// Image is a base64-encoded JPEG (optionally with a data: prefix) or an http(s) URL.
+	Image string
+}
+
+type SetGroupPictureResponse struct {
+	PictureID string `json:"pictureId"`
+}
+
+func (s *Whatsmiau) SetGroupPicture(ctx context.Context, req *SetGroupPictureRequest) (*SetGroupPictureResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	if req.Image == "" {
+		return nil, fmt.Errorf("image is required")
+	}
+
+	imgBytes, err := s.decodeImageInput(ctx, req.Image)
+	if err != nil {
+		return nil, err
+	}
+
+	pid, err := client.SetGroupPhoto(ctx, *req.GroupJID, imgBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &SetGroupPictureResponse{PictureID: pid}, nil
+}
+
+func (s *Whatsmiau) decodeImageInput(ctx context.Context, input string) ([]byte, error) {
+	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
+		return s.fetchBytes(ctx, input)
+	}
+	if idx := strings.Index(input, ","); strings.HasPrefix(input, "data:") && idx > 0 {
+		input = input[idx+1:]
+	}
+	decoded, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return nil, fmt.Errorf("image must be base64 or http(s) url: %w", err)
+	}
+	return decoded, nil
+}
+
+// ---------- SetGroupDescription ----------
+
+type SetGroupDescriptionRequest struct {
+	InstanceID  string
+	GroupJID    *types.JID
+	Description string
+}
+
+func (s *Whatsmiau) SetGroupDescription(ctx context.Context, req *SetGroupDescriptionRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	return client.SetGroupDescription(ctx, *req.GroupJID, req.Description)
+}
+
+// ---------- FindGroup ----------
+
+type FindGroupRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+}
+
+func (s *Whatsmiau) FindGroup(ctx context.Context, req *FindGroupRequest) (*GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	info, err := client.GetGroupInfo(ctx, *req.GroupJID)
+	if err != nil {
+		return nil, err
+	}
+	resp := s.buildGroupInfoResponse(ctx, req.InstanceID, info, true)
+	return &resp, nil
+}
+
+// ---------- FetchAllGroups ----------
+
+type FetchAllGroupsRequest struct {
+	InstanceID      string
+	GetParticipants bool
+}
+
+func (s *Whatsmiau) FetchAllGroups(ctx context.Context, req *FetchAllGroupsRequest) ([]GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	groups, err := client.GetJoinedGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]GroupInfoResponse, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, s.buildGroupInfoResponse(ctx, req.InstanceID, g, req.GetParticipants))
+	}
+	return out, nil
+}
+
+// ---------- FindParticipants ----------
+
+type FindParticipantsRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+}
+
+type FindParticipantsResponse struct {
+	Participants []GroupParticipantResponse `json:"participants"`
+}
+
+func (s *Whatsmiau) FindParticipants(ctx context.Context, req *FindParticipantsRequest) (*FindParticipantsResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	info, err := client.GetGroupInfo(ctx, *req.GroupJID)
+	if err != nil {
+		return nil, err
+	}
+	return &FindParticipantsResponse{
+		Participants: s.mapParticipants(ctx, req.InstanceID, info.Participants),
+	}, nil
+}
+
+// ---------- Invite Code ----------
+
+type InviteCodeRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+}
+
+type InviteCodeResponse struct {
+	InviteURL  string `json:"inviteUrl"`
+	InviteCode string `json:"inviteCode"`
+}
+
+func (s *Whatsmiau) GetGroupInviteCode(ctx context.Context, req *InviteCodeRequest) (*InviteCodeResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	link, err := client.GetGroupInviteLink(ctx, *req.GroupJID, false)
+	if err != nil {
+		return nil, err
+	}
+	return &InviteCodeResponse{
+		InviteURL:  link,
+		InviteCode: strings.TrimPrefix(link, whatsmeow.InviteLinkPrefix),
+	}, nil
+}
+
+func (s *Whatsmiau) RevokeGroupInviteCode(ctx context.Context, req *InviteCodeRequest) (*InviteCodeResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	link, err := client.GetGroupInviteLink(ctx, *req.GroupJID, true)
+	if err != nil {
+		return nil, err
+	}
+	return &InviteCodeResponse{
+		InviteURL:  link,
+		InviteCode: strings.TrimPrefix(link, whatsmeow.InviteLinkPrefix),
+	}, nil
+}
+
+type InviteInfoRequest struct {
+	InstanceID string
+	Code       string
+}
+
+func (s *Whatsmiau) GetGroupInviteInfo(ctx context.Context, req *InviteInfoRequest) (*GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	info, err := client.GetGroupInfoFromLink(ctx, req.Code)
+	if err != nil {
+		return nil, err
+	}
+	resp := s.buildGroupInfoResponse(ctx, req.InstanceID, info, true)
+	return &resp, nil
+}
+
+type AcceptGroupInviteRequest struct {
+	InstanceID string
+	Code       string
+}
+
+type AcceptGroupInviteResponse struct {
+	GroupJid string `json:"groupJid"`
+}
+
+func (s *Whatsmiau) AcceptGroupInvite(ctx context.Context, req *AcceptGroupInviteRequest) (*AcceptGroupInviteResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	jid, err := client.JoinGroupWithLink(ctx, req.Code)
+	if err != nil {
+		return nil, err
+	}
+	return &AcceptGroupInviteResponse{GroupJid: jid.String()}, nil
+}
+
+// ---------- Send Invite to numbers ----------
+
+type SendGroupInviteRequest struct {
+	InstanceID  string
+	GroupJID    *types.JID
+	Description string
+	Numbers     []string
+}
+
+type SendInviteResult struct {
+	Number  string `json:"number"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+type SendGroupInviteResponse struct {
+	InviteURL string             `json:"inviteUrl"`
+	Sent      []SendInviteResult `json:"sent"`
+}
+
+func (s *Whatsmiau) SendGroupInvite(ctx context.Context, req *SendGroupInviteRequest) (*SendGroupInviteResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	link, err := client.GetGroupInviteLink(ctx, *req.GroupJID, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invite link: %w", err)
+	}
+
+	body := link
+	if req.Description != "" {
+		body = req.Description + "\n\n" + link
+	}
+
+	results := make([]SendInviteResult, len(req.Numbers))
+	var wg sync.WaitGroup
+	for i, number := range req.Numbers {
+		wg.Add(1)
+		go func(i int, number string) {
+			defer wg.Done()
+
+			target, parseErr := normalizeUserJID(number)
+			if parseErr != nil {
+				results[i] = SendInviteResult{Number: number, Success: false, Error: parseErr.Error()}
+				return
+			}
+
+			resolved := s.resolveJID(ctx, client, *target)
+			_, sendErr := client.SendMessage(ctx, resolved, &waE2E.Message{
+				Conversation: &body,
+			})
+			if sendErr != nil {
+				results[i] = SendInviteResult{Number: number, Success: false, Error: sendErr.Error()}
+				return
+			}
+			results[i] = SendInviteResult{Number: number, Success: true}
+		}(i, number)
+	}
+	wg.Wait()
+
+	return &SendGroupInviteResponse{
+		InviteURL: link,
+		Sent:      results,
+	}, nil
+}
+
+// ---------- UpdateParticipant ----------
+
+type UpdateParticipantRequest struct {
+	InstanceID   string
+	GroupJID     *types.JID
+	Action       string
+	Participants []string
+}
+
+type UpdateParticipantResponse struct {
+	Participants []GroupParticipantResponse `json:"participants"`
+}
+
+func (s *Whatsmiau) UpdateGroupParticipant(ctx context.Context, req *UpdateParticipantRequest) (*UpdateParticipantResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	var action whatsmeow.ParticipantChange
+	switch req.Action {
+	case "add":
+		action = whatsmeow.ParticipantChangeAdd
+	case "remove":
+		action = whatsmeow.ParticipantChangeRemove
+	case "promote":
+		action = whatsmeow.ParticipantChangePromote
+	case "demote":
+		action = whatsmeow.ParticipantChangeDemote
+	default:
+		return nil, fmt.Errorf("invalid action: %s", req.Action)
+	}
+
+	jids, err := s.numbersToJIDs(ctx, client, req.Participants, true)
+	if err != nil {
+		return nil, err
+	}
+
+	participants, err := client.UpdateGroupParticipants(ctx, *req.GroupJID, jids, action)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateParticipantResponse{
+		Participants: s.mapParticipants(ctx, req.InstanceID, participants),
+	}, nil
+}
+
+// ---------- UpdateSetting ----------
+
+type UpdateGroupSettingRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+	Action     string
+}
+
+func (s *Whatsmiau) UpdateGroupSetting(ctx context.Context, req *UpdateGroupSettingRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+
+	switch req.Action {
+	case "announcement":
+		return client.SetGroupAnnounce(ctx, *req.GroupJID, true)
+	case "not_announcement":
+		return client.SetGroupAnnounce(ctx, *req.GroupJID, false)
+	case "locked":
+		return client.SetGroupLocked(ctx, *req.GroupJID, true)
+	case "unlocked":
+		return client.SetGroupLocked(ctx, *req.GroupJID, false)
+	default:
+		return fmt.Errorf("invalid action: %s", req.Action)
+	}
+}
+
+// ---------- Toggle Ephemeral ----------
+
+type ToggleEphemeralRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+	Expiration uint32
+}
+
+func (s *Whatsmiau) ToggleGroupEphemeral(ctx context.Context, req *ToggleEphemeralRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	return client.SetDisappearingTimer(ctx, *req.GroupJID, time.Duration(req.Expiration)*time.Second, time.Time{})
+}
+
+// ---------- LeaveGroup ----------
+
+type LeaveGroupRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+}
+
+func (s *Whatsmiau) LeaveGroup(ctx context.Context, req *LeaveGroupRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	return client.LeaveGroup(ctx, *req.GroupJID)
+}
+
+// ---------- Community: Create ----------
+
+type CreateCommunityRequest struct {
+	InstanceID  string
+	Subject     string
+	Description string
+}
+
+func (s *Whatsmiau) CreateCommunity(ctx context.Context, req *CreateCommunityRequest) (*GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	created, err := client.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
+		Name: req.Subject,
+		GroupParent: types.GroupParent{
+			IsParent: true,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create community: %w", err)
+	}
+
+	if req.Description != "" {
+		if err := client.SetGroupDescription(ctx, created.JID, req.Description); err != nil {
+			zap.L().Warn("community created but failed to set description", zap.Error(err), zap.String("community", created.JID.String()))
+		}
+	}
+
+	info, err := client.GetGroupInfo(ctx, created.JID)
+	if err != nil {
+		resp := s.buildGroupInfoResponse(ctx, req.InstanceID, created, false)
+		return &resp, nil
+	}
+	resp := s.buildGroupInfoResponse(ctx, req.InstanceID, info, false)
+	return &resp, nil
+}
+
+// ---------- Community: Create SubGroup ----------
+
+type CreateSubGroupRequest struct {
+	InstanceID   string
+	Subject      string
+	ParentJID    *types.JID
+	Participants []string
+}
+
+func (s *Whatsmiau) CreateCommunitySubGroup(ctx context.Context, req *CreateSubGroupRequest) (*GroupInfoResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	participantJids, err := s.numbersToJIDs(ctx, client, req.Participants, true)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := client.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
+		Name:         req.Subject,
+		Participants: participantJids,
+		GroupLinkedParent: types.GroupLinkedParent{
+			LinkedParentJID: *req.ParentJID,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sub group: %w", err)
+	}
+
+	info, err := client.GetGroupInfo(ctx, created.JID)
+	if err != nil {
+		resp := s.buildGroupInfoResponse(ctx, req.InstanceID, created, true)
+		return &resp, nil
+	}
+	resp := s.buildGroupInfoResponse(ctx, req.InstanceID, info, true)
+	return &resp, nil
+}
+
+// ---------- Community: Link / Unlink ----------
+
+type LinkGroupRequest struct {
+	InstanceID string
+	ParentJID  *types.JID
+	ChildJID   *types.JID
+}
+
+func (s *Whatsmiau) LinkCommunityGroup(ctx context.Context, req *LinkGroupRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+
+	err := client.LinkGroup(ctx, *req.ParentJID, *req.ChildJID)
+	if err != nil {
+		if errors.Is(err, whatsmeow.ErrIQNotAuthorized) || errors.Is(err, whatsmeow.ErrIQForbidden) {
+			return fmt.Errorf("you must be an admin of the parent community to link groups: %w", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Whatsmiau) UnlinkCommunityGroup(ctx context.Context, req *LinkGroupRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+
+	err := client.UnlinkGroup(ctx, *req.ParentJID, *req.ChildJID)
+	if err != nil {
+		if errors.Is(err, whatsmeow.ErrIQNotAuthorized) || errors.Is(err, whatsmeow.ErrIQForbidden) {
+			return fmt.Errorf("you must be an admin of the parent community to unlink groups: %w", err)
+		}
+		return err
+	}
+	return nil
+}
+
+// ---------- Community: SubGroups list ----------
+
+type SubGroupsRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+}
+
+type SubGroupResponse struct {
+	Id                string `json:"id"`
+	Subject           string `json:"subject"`
+	SubjectTime       int64  `json:"subjectTime,omitempty"`
+	IsDefaultSubGroup bool   `json:"isDefaultSubGroup"`
+}
+
+func (s *Whatsmiau) GetCommunitySubGroups(ctx context.Context, req *SubGroupsRequest) ([]SubGroupResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	subs, err := client.GetSubGroups(ctx, *req.CommunityJID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]SubGroupResponse, 0, len(subs))
+	for _, sg := range subs {
+		out = append(out, SubGroupResponse{
+			Id:                sg.JID.String(),
+			Subject:           sg.Name,
+			SubjectTime:       sg.NameSetAt.Unix(),
+			IsDefaultSubGroup: sg.IsDefaultSubGroup,
+		})
+	}
+	return out, nil
+}
+
+// ---------- Community: Linked groups participants ----------
+
+type LinkedGroupsParticipantsRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+}
+
+type LinkedParticipantResponse struct {
+	Jid string `json:"jid"`
+	Lid string `json:"lid"`
+}
+
+func (s *Whatsmiau) GetCommunityLinkedGroupsParticipants(ctx context.Context, req *LinkedGroupsParticipantsRequest) ([]LinkedParticipantResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	participants, err := client.GetLinkedGroupsParticipants(ctx, *req.CommunityJID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LinkedParticipantResponse, 0, len(participants))
+	for _, p := range participants {
+		jid, lid := s.GetJidLid(ctx, req.InstanceID, p)
+		out = append(out, LinkedParticipantResponse{Jid: jid, Lid: lid})
+	}
+	return out, nil
+}
+
+// ---------- Community: Settings ----------
+
+type SetJoinApprovalModeRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+	Mode         bool
+}
+
+func (s *Whatsmiau) SetCommunityJoinApprovalMode(ctx context.Context, req *SetJoinApprovalModeRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+	return client.SetGroupJoinApprovalMode(ctx, *req.CommunityJID, req.Mode)
+}
+
+type SetMemberAddModeRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+	Mode         string
+}
+
+func (s *Whatsmiau) SetCommunityMemberAddMode(ctx context.Context, req *SetMemberAddModeRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+
+	var mode types.GroupMemberAddMode
+	switch req.Mode {
+	case "admin_add":
+		mode = types.GroupMemberAddModeAdmin
+	case "all_member_add":
+		mode = types.GroupMemberAddModeAllMember
+	default:
+		return fmt.Errorf("invalid mode: %s", req.Mode)
+	}
+	return client.SetGroupMemberAddMode(ctx, *req.CommunityJID, mode)
+}
+
+// ---------- Community: Request participants ----------
+
+type RequestParticipantsListRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+}
+
+type RequestParticipantResponse struct {
+	Jid         string `json:"jid"`
+	Lid         string `json:"lid"`
+	RequestedAt int64  `json:"requestedAt"`
+}
+
+func (s *Whatsmiau) GetCommunityRequestParticipants(ctx context.Context, req *RequestParticipantsListRequest) ([]RequestParticipantResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	requests, err := client.GetGroupRequestParticipants(ctx, *req.CommunityJID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]RequestParticipantResponse, 0, len(requests))
+	for _, r := range requests {
+		jid, lid := s.GetJidLid(ctx, req.InstanceID, r.JID)
+		out = append(out, RequestParticipantResponse{
+			Jid:         jid,
+			Lid:         lid,
+			RequestedAt: r.RequestedAt.Unix(),
+		})
+	}
+	return out, nil
+}
+
+type UpdateRequestParticipantsRequest struct {
+	InstanceID   string
+	CommunityJID *types.JID
+	Action       string
+	Participants []string
+}
+
+func (s *Whatsmiau) UpdateCommunityRequestParticipants(ctx context.Context, req *UpdateRequestParticipantsRequest) (*UpdateParticipantResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+
+	var action whatsmeow.ParticipantRequestChange
+	switch req.Action {
+	case "approve":
+		action = whatsmeow.ParticipantChangeApprove
+	case "reject":
+		action = whatsmeow.ParticipantChangeReject
+	default:
+		return nil, fmt.Errorf("invalid action: %s", req.Action)
+	}
+
+	jids, err := s.numbersToJIDs(ctx, client, req.Participants, true)
+	if err != nil {
+		return nil, err
+	}
+
+	participants, err := client.UpdateGroupRequestParticipants(ctx, *req.CommunityJID, jids, action)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateParticipantResponse{
+		Participants: s.mapParticipants(ctx, req.InstanceID, participants),
+	}, nil
+}
+
+// ---------- helpers ----------
+
+// numbersToJIDs converts a list of phone numbers (raw or jid-format) into types.JID.
+// When resolve is true, applies brazilian-alternate resolution via resolveJID.
+func (s *Whatsmiau) numbersToJIDs(ctx context.Context, client *whatsmeow.Client, numbers []string, resolve bool) ([]types.JID, error) {
+	out := make([]types.JID, 0, len(numbers))
+	for _, n := range numbers {
+		jid, err := normalizeUserJID(n)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q: %w", n, err)
+		}
+		if resolve {
+			resolved := s.resolveJID(ctx, client, *jid)
+			out = append(out, resolved)
+		} else {
+			out = append(out, *jid)
+		}
+	}
+	return out, nil
+}
+
+// normalizeUserJID accepts "55..." or "55...@s.whatsapp.net" or "lid@lid" and returns a types.JID.
+// Differs from controllers.numberToJid by not enforcing minimum length (already validated upstream).
+func normalizeUserJID(input string) (*types.JID, error) {
+	if input == "" {
+		return nil, fmt.Errorf("empty number")
+	}
+	if !strings.Contains(input, "@") {
+		input += "@" + types.DefaultUserServer
+	}
+	jid, err := types.ParseJID(input)
+	if err != nil {
+		return nil, err
+	}
+	return &jid, nil
+}

--- a/server/controllers/community.go
+++ b/server/controllers/community.go
@@ -1,0 +1,381 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/interfaces"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/server/dto"
+	"github.com/verbeux-ai/whatsmiau/utils"
+	"go.uber.org/zap"
+)
+
+type Community struct {
+	repo      interfaces.InstanceRepository
+	whatsmiau *whatsmiau.Whatsmiau
+}
+
+func NewCommunities(repository interfaces.InstanceRepository, whatsmiau *whatsmiau.Whatsmiau) *Community {
+	return &Community{
+		repo:      repository,
+		whatsmiau: whatsmiau,
+	}
+}
+
+// CreateCommunity godoc
+// @Summary      Create a WhatsApp community (parent group)
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                   true  "Instance ID"
+// @Param        body      body  dto.CreateCommunityRequest true  "Community payload"
+// @Success      201       {object}  whatsmiau.GroupInfoResponse
+// @Router       /instance/{instance}/community/create [post]
+func (s *Community) CreateCommunity(ctx echo.Context) error {
+	var request dto.CreateCommunityRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	resp, err := s.whatsmiau.CreateCommunity(ctx.Request().Context(), &whatsmiau.CreateCommunityRequest{
+		InstanceID:  request.InstanceID,
+		Subject:     request.Subject,
+		Description: request.Description,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.CreateCommunity failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// CreateSubGroup godoc
+// @Summary      Create a new group already linked to a community
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                            true  "Instance ID"
+// @Param        body      body  dto.CreateCommunitySubGroupRequest true  "Sub group payload"
+// @Success      201       {object}  whatsmiau.GroupInfoResponse
+// @Router       /instance/{instance}/community/createSubGroup [post]
+func (s *Community) CreateSubGroup(ctx echo.Context) error {
+	var request dto.CreateCommunitySubGroupRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	parentJid, err := parseGroupJID(request.ParentJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid parentJid")
+	}
+
+	resp, err := s.whatsmiau.CreateCommunitySubGroup(ctx.Request().Context(), &whatsmiau.CreateSubGroupRequest{
+		InstanceID:   request.InstanceID,
+		Subject:      request.Subject,
+		ParentJID:    parentJid,
+		Participants: request.Participants,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.CreateCommunitySubGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// LinkGroup godoc
+// @Summary      Link an existing group to a community
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                       true  "Instance ID"
+// @Param        body      body  dto.CommunityLinkGroupRequest true  "Link payload"
+// @Success      200       {object}  map[string]interface{}
+// @Router       /instance/{instance}/community/linkGroup [post]
+func (s *Community) LinkGroup(ctx echo.Context) error {
+	var request dto.CommunityLinkGroupRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	parentJid, err := parseGroupJID(request.ParentJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid parentJid")
+	}
+	childJid, err := parseGroupJID(request.ChildJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid childJid")
+	}
+
+	if err := s.whatsmiau.LinkCommunityGroup(ctx.Request().Context(), &whatsmiau.LinkGroupRequest{
+		InstanceID: request.InstanceID,
+		ParentJID:  parentJid,
+		ChildJID:   childJid,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.LinkCommunityGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{})
+}
+
+// UnlinkGroup godoc
+// @Summary      Remove a group from a community
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                       true  "Instance ID"
+// @Param        body      body  dto.CommunityLinkGroupRequest true  "Unlink payload"
+// @Success      200       {object}  map[string]interface{}
+// @Router       /instance/{instance}/community/unlinkGroup [post]
+func (s *Community) UnlinkGroup(ctx echo.Context) error {
+	var request dto.CommunityLinkGroupRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	parentJid, err := parseGroupJID(request.ParentJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid parentJid")
+	}
+	childJid, err := parseGroupJID(request.ChildJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid childJid")
+	}
+
+	if err := s.whatsmiau.UnlinkCommunityGroup(ctx.Request().Context(), &whatsmiau.LinkGroupRequest{
+		InstanceID: request.InstanceID,
+		ParentJID:  parentJid,
+		ChildJID:   childJid,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.UnlinkCommunityGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{})
+}
+
+// SubGroups godoc
+// @Summary      List subgroups of a community
+// @Tags         Community
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance      path  string true  "Instance ID"
+// @Param        communityJid  query string true  "Community JID"
+// @Success      200  {array}  whatsmiau.SubGroupResponse
+// @Router       /instance/{instance}/community/subGroups [get]
+func (s *Community) SubGroups(ctx echo.Context) error {
+	var request dto.CommunityJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	resp, err := s.whatsmiau.GetCommunitySubGroups(ctx.Request().Context(), &whatsmiau.SubGroupsRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.GetCommunitySubGroups failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// LinkedGroupsParticipants godoc
+// @Summary      List participants across all linked groups of a community
+// @Tags         Community
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance      path  string true  "Instance ID"
+// @Param        communityJid  query string true  "Community JID"
+// @Success      200  {array}  whatsmiau.LinkedParticipantResponse
+// @Router       /instance/{instance}/community/linkedGroupsParticipants [get]
+func (s *Community) LinkedGroupsParticipants(ctx echo.Context) error {
+	var request dto.CommunityJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	resp, err := s.whatsmiau.GetCommunityLinkedGroupsParticipants(ctx.Request().Context(), &whatsmiau.LinkedGroupsParticipantsRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.GetCommunityLinkedGroupsParticipants failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// SetJoinApprovalMode godoc
+// @Summary      Toggle join-approval mode for a community
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                                 true  "Instance ID"
+// @Param        body      body  dto.CommunitySetJoinApprovalModeRequest true  "Mode payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/community/setJoinApprovalMode [post]
+func (s *Community) SetJoinApprovalMode(ctx echo.Context) error {
+	var request dto.CommunitySetJoinApprovalModeRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	if err := s.whatsmiau.SetCommunityJoinApprovalMode(ctx.Request().Context(), &whatsmiau.SetJoinApprovalModeRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+		Mode:         request.Mode,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.SetCommunityJoinApprovalMode failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// SetMemberAddMode godoc
+// @Summary      Toggle who can add members (admins only or all)
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                              true  "Instance ID"
+// @Param        body      body  dto.CommunitySetMemberAddModeRequest true  "Mode payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/community/setMemberAddMode [post]
+func (s *Community) SetMemberAddMode(ctx echo.Context) error {
+	var request dto.CommunitySetMemberAddModeRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	if err := s.whatsmiau.SetCommunityMemberAddMode(ctx.Request().Context(), &whatsmiau.SetMemberAddModeRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+		Mode:         request.Mode,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.SetCommunityMemberAddMode failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// RequestParticipants godoc
+// @Summary      List pending join requests
+// @Tags         Community
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance      path  string true  "Instance ID"
+// @Param        communityJid  query string true  "Community JID"
+// @Success      200  {array}  whatsmiau.RequestParticipantResponse
+// @Router       /instance/{instance}/community/requestParticipants [get]
+func (s *Community) RequestParticipants(ctx echo.Context) error {
+	var request dto.CommunityJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	resp, err := s.whatsmiau.GetCommunityRequestParticipants(ctx.Request().Context(), &whatsmiau.RequestParticipantsListRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.GetCommunityRequestParticipants failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// UpdateRequestParticipants godoc
+// @Summary      Approve or reject pending join requests
+// @Tags         Community
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string                                          true  "Instance ID"
+// @Param        body      body  dto.CommunityUpdateRequestParticipantsRequest true  "Update payload"
+// @Success      201       {object}  whatsmiau.UpdateParticipantResponse
+// @Router       /instance/{instance}/community/requestParticipants/update [post]
+func (s *Community) UpdateRequestParticipants(ctx echo.Context) error {
+	var request dto.CommunityUpdateRequestParticipantsRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	communityJid, err := parseGroupJID(request.CommunityJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid communityJid")
+	}
+
+	resp, err := s.whatsmiau.UpdateCommunityRequestParticipants(ctx.Request().Context(), &whatsmiau.UpdateRequestParticipantsRequest{
+		InstanceID:   request.InstanceID,
+		CommunityJID: communityJid,
+		Action:       request.Action,
+		Participants: request.Participants,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.UpdateCommunityRequestParticipants failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}

--- a/server/controllers/group.go
+++ b/server/controllers/group.go
@@ -1,0 +1,611 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/interfaces"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/server/dto"
+	"github.com/verbeux-ai/whatsmiau/utils"
+	"go.mau.fi/whatsmeow"
+	"go.uber.org/zap"
+)
+
+type Group struct {
+	repo      interfaces.InstanceRepository
+	whatsmiau *whatsmiau.Whatsmiau
+}
+
+func NewGroups(repository interfaces.InstanceRepository, whatsmiau *whatsmiau.Whatsmiau) *Group {
+	return &Group{
+		repo:      repository,
+		whatsmiau: whatsmiau,
+	}
+}
+
+func mapGroupError(err error) (int, string) {
+	switch {
+	case errors.Is(err, whatsmeow.ErrClientIsNil):
+		return http.StatusNotFound, "instance is not connected"
+	case errors.Is(err, whatsmeow.ErrGroupNotFound):
+		return http.StatusNotFound, "group not found"
+	case errors.Is(err, whatsmeow.ErrNotInGroup):
+		return http.StatusForbidden, "not a member of this group"
+	case errors.Is(err, whatsmeow.ErrInviteLinkRevoked):
+		return http.StatusGone, "invite link revoked"
+	case errors.Is(err, whatsmeow.ErrInviteLinkInvalid):
+		return http.StatusBadRequest, "invite link invalid"
+	case errors.Is(err, whatsmeow.ErrGroupInviteLinkUnauthorized):
+		return http.StatusForbidden, "unauthorized to access invite link"
+	case errors.Is(err, whatsmeow.ErrIQRateOverLimit):
+		return http.StatusTooManyRequests, "rate limit exceeded, try again later"
+	default:
+		return http.StatusInternalServerError, "operation failed"
+	}
+}
+
+// CreateGroup godoc
+// @Summary      Create a WhatsApp group
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                 true  "Instance ID"
+// @Param        body      body      dto.CreateGroupRequest true  "Group payload"
+// @Success      201       {object}  whatsmiau.GroupInfoResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /instance/{instance}/group/create [post]
+// @Router       /group/create/{instance} [post]
+func (s *Group) CreateGroup(ctx echo.Context) error {
+	var request dto.CreateGroupRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	resp, err := s.whatsmiau.CreateGroup(ctx.Request().Context(), &whatsmiau.CreateGroupRequest{
+		InstanceID:          request.InstanceID,
+		Subject:             request.Subject,
+		Description:         request.Description,
+		Participants:        request.Participants,
+		PromoteParticipants: request.PromoteParticipants,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.CreateGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// UpdateGroupSubject godoc
+// @Summary      Update group subject (name)
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                  true  "Instance ID"
+// @Param        body      body      dto.GroupSubjectRequest true  "Subject payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/group/updateGroupSubject [post]
+// @Router       /group/updateGroupSubject/{instance} [post]
+func (s *Group) UpdateGroupSubject(ctx echo.Context) error {
+	var request dto.GroupSubjectRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.SetGroupSubject(ctx.Request().Context(), &whatsmiau.SetGroupSubjectRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+		Subject:    request.Subject,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.SetGroupSubject failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// UpdateGroupPicture godoc
+// @Summary      Update group picture
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                  true  "Instance ID"
+// @Param        body      body      dto.GroupPictureRequest true  "Picture payload (base64 or URL)"
+// @Success      201       {object}  whatsmiau.SetGroupPictureResponse
+// @Router       /instance/{instance}/group/updateGroupPicture [post]
+// @Router       /group/updateGroupPicture/{instance} [post]
+func (s *Group) UpdateGroupPicture(ctx echo.Context) error {
+	var request dto.GroupPictureRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.SetGroupPicture(ctx.Request().Context(), &whatsmiau.SetGroupPictureRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+		Image:      request.Image,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.SetGroupPicture failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// UpdateGroupDescription godoc
+// @Summary      Update group description
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                      true  "Instance ID"
+// @Param        body      body      dto.GroupDescriptionRequest true  "Description payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/group/updateGroupDescription [post]
+// @Router       /group/updateGroupDescription/{instance} [post]
+func (s *Group) UpdateGroupDescription(ctx echo.Context) error {
+	var request dto.GroupDescriptionRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.SetGroupDescription(ctx.Request().Context(), &whatsmiau.SetGroupDescriptionRequest{
+		InstanceID:  request.InstanceID,
+		GroupJID:    groupJid,
+		Description: request.Description,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.SetGroupDescription failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// FindGroupInfos godoc
+// @Summary      Get group info by JID
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path   string true  "Instance ID"
+// @Param        groupJid  query  string true  "Group JID"
+// @Success      200  {object}  whatsmiau.GroupInfoResponse
+// @Router       /instance/{instance}/group/findGroupInfos [get]
+// @Router       /group/findGroupInfos/{instance} [get]
+func (s *Group) FindGroupInfos(ctx echo.Context) error {
+	var request dto.GroupJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.FindGroup(ctx.Request().Context(), &whatsmiau.FindGroupRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.FindGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// FetchAllGroups godoc
+// @Summary      List all joined groups
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance         path   string true  "Instance ID"
+// @Param        getParticipants  query  string false "Include participants (true/false)"
+// @Success      200  {array}  whatsmiau.GroupInfoResponse
+// @Router       /instance/{instance}/group/fetchAllGroups [get]
+// @Router       /group/fetchAllGroups/{instance} [get]
+func (s *Group) FetchAllGroups(ctx echo.Context) error {
+	var request dto.FetchAllGroupsQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+
+	resp, err := s.whatsmiau.FetchAllGroups(ctx.Request().Context(), &whatsmiau.FetchAllGroupsRequest{
+		InstanceID:      request.InstanceID,
+		GetParticipants: request.GetParticipants == "true",
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.FetchAllGroups failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// FindParticipants godoc
+// @Summary      List participants of a group
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path   string true  "Instance ID"
+// @Param        groupJid  query  string true  "Group JID"
+// @Success      200  {object}  whatsmiau.FindParticipantsResponse
+// @Router       /instance/{instance}/group/participants [get]
+// @Router       /group/participants/{instance} [get]
+func (s *Group) FindParticipants(ctx echo.Context) error {
+	var request dto.GroupJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.FindParticipants(ctx.Request().Context(), &whatsmiau.FindParticipantsRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.FindParticipants failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// InviteCode godoc
+// @Summary      Get the group invite code (link)
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path   string true  "Instance ID"
+// @Param        groupJid  query  string true  "Group JID"
+// @Success      200  {object}  whatsmiau.InviteCodeResponse
+// @Router       /instance/{instance}/group/inviteCode [get]
+// @Router       /group/inviteCode/{instance} [get]
+func (s *Group) InviteCode(ctx echo.Context) error {
+	var request dto.GroupJidQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.GetGroupInviteCode(ctx.Request().Context(), &whatsmiau.InviteCodeRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.GetGroupInviteCode failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// InviteInfo godoc
+// @Summary      Get info about an invite code (no join)
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance    path   string true  "Instance ID"
+// @Param        inviteCode  query  string true  "Invite code or full link"
+// @Success      200  {object}  whatsmiau.GroupInfoResponse
+// @Router       /instance/{instance}/group/inviteInfo [get]
+// @Router       /group/inviteInfo/{instance} [get]
+func (s *Group) InviteInfo(ctx echo.Context) error {
+	var request dto.GroupInviteCodeQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+
+	resp, err := s.whatsmiau.GetGroupInviteInfo(ctx.Request().Context(), &whatsmiau.InviteInfoRequest{
+		InstanceID: request.InstanceID,
+		Code:       request.InviteCode,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.GetGroupInviteInfo failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// AcceptInviteCode godoc
+// @Summary      Join a group using an invite code
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance    path   string true  "Instance ID"
+// @Param        inviteCode  query  string true  "Invite code or full link"
+// @Success      200  {object}  whatsmiau.AcceptGroupInviteResponse
+// @Router       /instance/{instance}/group/acceptInviteCode [get]
+// @Router       /group/acceptInviteCode/{instance} [get]
+func (s *Group) AcceptInviteCode(ctx echo.Context) error {
+	var request dto.GroupInviteCodeQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+
+	resp, err := s.whatsmiau.AcceptGroupInvite(ctx.Request().Context(), &whatsmiau.AcceptGroupInviteRequest{
+		InstanceID: request.InstanceID,
+		Code:       request.InviteCode,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.AcceptGroupInvite failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// SendInvite godoc
+// @Summary      Send group invite link via text to phone numbers
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                     true  "Instance ID"
+// @Param        body      body      dto.GroupSendInviteRequest true  "Invite payload"
+// @Success      200       {object}  whatsmiau.SendGroupInviteResponse
+// @Router       /instance/{instance}/group/sendInvite [post]
+// @Router       /group/sendInvite/{instance} [post]
+func (s *Group) SendInvite(ctx echo.Context) error {
+	var request dto.GroupSendInviteRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.SendGroupInvite(ctx.Request().Context(), &whatsmiau.SendGroupInviteRequest{
+		InstanceID:  request.InstanceID,
+		GroupJID:    groupJid,
+		Description: request.Description,
+		Numbers:     request.Numbers,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.SendGroupInvite failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// RevokeInviteCode godoc
+// @Summary      Revoke current invite code and generate a new one
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string true  "Instance ID"
+// @Param        body      body  dto.GroupRevokeInviteRequest true  "Group payload"
+// @Success      201       {object}  whatsmiau.InviteCodeResponse
+// @Router       /instance/{instance}/group/revokeInviteCode [post]
+// @Router       /group/revokeInviteCode/{instance} [post]
+func (s *Group) RevokeInviteCode(ctx echo.Context) error {
+	var request dto.GroupRevokeInviteRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.RevokeGroupInviteCode(ctx.Request().Context(), &whatsmiau.InviteCodeRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.RevokeGroupInviteCode failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// UpdateParticipant godoc
+// @Summary      Update group participants (add/remove/promote/demote)
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string true  "Instance ID"
+// @Param        body      body  dto.GroupUpdateParticipantRequest true  "Update payload"
+// @Success      201       {object}  whatsmiau.UpdateParticipantResponse
+// @Router       /instance/{instance}/group/updateParticipant [post]
+// @Router       /group/updateParticipant/{instance} [post]
+func (s *Group) UpdateParticipant(ctx echo.Context) error {
+	var request dto.GroupUpdateParticipantRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	resp, err := s.whatsmiau.UpdateGroupParticipant(ctx.Request().Context(), &whatsmiau.UpdateParticipantRequest{
+		InstanceID:   request.InstanceID,
+		GroupJID:     groupJid,
+		Action:       request.Action,
+		Participants: request.Participants,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.UpdateGroupParticipant failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+// UpdateSetting godoc
+// @Summary      Update group setting (announce/locked)
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string true  "Instance ID"
+// @Param        body      body  dto.GroupUpdateSettingRequest true  "Setting payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/group/updateSetting [post]
+// @Router       /group/updateSetting/{instance} [post]
+func (s *Group) UpdateSetting(ctx echo.Context) error {
+	var request dto.GroupUpdateSettingRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.UpdateGroupSetting(ctx.Request().Context(), &whatsmiau.UpdateGroupSettingRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+		Action:     request.Action,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.UpdateGroupSetting failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// ToggleEphemeral godoc
+// @Summary      Toggle disappearing messages for the group
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string true  "Instance ID"
+// @Param        body      body  dto.GroupToggleEphemeralRequest true  "Ephemeral payload"
+// @Success      201       {object}  map[string]interface{}
+// @Router       /instance/{instance}/group/toggleEphemeral [post]
+// @Router       /group/toggleEphemeral/{instance} [post]
+func (s *Group) ToggleEphemeral(ctx echo.Context) error {
+	var request dto.GroupToggleEphemeralRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.ToggleGroupEphemeral(ctx.Request().Context(), &whatsmiau.ToggleEphemeralRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+		Expiration: request.Expiration,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.ToggleGroupEphemeral failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
+// LeaveGroup godoc
+// @Summary      Leave a group
+// @Tags         Group
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path   string true  "Instance ID"
+// @Param        groupJid  query  string true  "Group JID"
+// @Success      200       {object}  map[string]interface{}
+// @Router       /instance/{instance}/group/leaveGroup [delete]
+// @Router       /group/leaveGroup/{instance} [delete]
+func (s *Group) LeaveGroup(ctx echo.Context) error {
+	var request dto.GroupLeaveRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.LeaveGroup(ctx.Request().Context(), &whatsmiau.LeaveGroupRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.LeaveGroup failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/server/controllers/helper.go
+++ b/server/controllers/helper.go
@@ -27,6 +27,27 @@ func numberToJid(number string) (*types.JID, error) {
 	return &jid, nil
 }
 
+func parseGroupJID(input string) (*types.JID, error) {
+	if input == "" {
+		return nil, fmt.Errorf("group jid is required")
+	}
+
+	if !strings.Contains(input, "@") {
+		input += "@" + types.GroupServer
+	}
+
+	jid, err := types.ParseJID(input)
+	if err != nil {
+		return nil, fmt.Errorf("invalid group jid: %w", err)
+	}
+
+	if jid.Server != types.GroupServer {
+		return nil, fmt.Errorf("not a group jid: %s", jid.String())
+	}
+
+	return &jid, nil
+}
+
 func parseProxyURL(proxyURL string) (*models.InstanceProxy, error) {
 	if !strings.Contains(proxyURL, "://") {
 		return nil, fmt.Errorf("invalid proxy url, missing scheme: %s", proxyURL)

--- a/server/dto/community.go
+++ b/server/dto/community.go
@@ -1,0 +1,44 @@
+package dto
+
+type CreateCommunityRequest struct {
+	InstanceID  string `param:"instance" validate:"required" swaggerignore:"true"`
+	Subject     string `json:"subject" validate:"required,min=1,max=25"`
+	Description string `json:"description,omitempty"`
+}
+
+type CreateCommunitySubGroupRequest struct {
+	InstanceID   string   `param:"instance" validate:"required" swaggerignore:"true"`
+	Subject      string   `json:"subject" validate:"required,min=1,max=25"`
+	ParentJid    string   `json:"parentJid" validate:"required"`
+	Participants []string `json:"participants" validate:"omitempty,dive,required"`
+}
+
+type CommunityLinkGroupRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	ParentJid  string `json:"parentJid" validate:"required"`
+	ChildJid   string `json:"childJid" validate:"required"`
+}
+
+type CommunityJidQuery struct {
+	InstanceID   string `param:"instance" validate:"required" swaggerignore:"true"`
+	CommunityJid string `query:"communityJid" validate:"required"`
+}
+
+type CommunitySetJoinApprovalModeRequest struct {
+	InstanceID   string `param:"instance" validate:"required" swaggerignore:"true"`
+	CommunityJid string `json:"communityJid" validate:"required"`
+	Mode         bool   `json:"mode"`
+}
+
+type CommunitySetMemberAddModeRequest struct {
+	InstanceID   string `param:"instance" validate:"required" swaggerignore:"true"`
+	CommunityJid string `json:"communityJid" validate:"required"`
+	Mode         string `json:"mode" validate:"required,oneof=admin_add all_member_add"`
+}
+
+type CommunityUpdateRequestParticipantsRequest struct {
+	InstanceID   string   `param:"instance" validate:"required" swaggerignore:"true"`
+	CommunityJid string   `json:"communityJid" validate:"required"`
+	Action       string   `json:"action" validate:"required,oneof=approve reject"`
+	Participants []string `json:"participants" validate:"omitempty,dive,required"`
+}

--- a/server/dto/group.go
+++ b/server/dto/group.go
@@ -1,0 +1,79 @@
+package dto
+
+type CreateGroupRequest struct {
+	InstanceID          string   `param:"instance" validate:"required" swaggerignore:"true"`
+	Subject             string   `json:"subject" validate:"required,min=1,max=25"`
+	Description         string   `json:"description,omitempty"`
+	Participants        []string `json:"participants" validate:"omitempty,dive,required"`
+	PromoteParticipants bool     `json:"promoteParticipants,omitempty"`
+}
+
+type GroupSubjectRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+	Subject    string `json:"subject" validate:"required,min=1,max=25"`
+}
+
+type GroupPictureRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+	// Image can be either a base64-encoded JPEG or a URL pointing to a JPEG.
+	Image string `json:"image" validate:"required"`
+}
+
+type GroupDescriptionRequest struct {
+	InstanceID  string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid    string `json:"groupJid" validate:"required"`
+	Description string `json:"description"`
+}
+
+type GroupJidQuery struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `query:"groupJid" validate:"required"`
+}
+
+type FetchAllGroupsQuery struct {
+	InstanceID      string `param:"instance" validate:"required" swaggerignore:"true"`
+	GetParticipants string `query:"getParticipants"`
+}
+
+type GroupInviteCodeQuery struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	InviteCode string `query:"inviteCode" validate:"required"`
+}
+
+type GroupSendInviteRequest struct {
+	InstanceID  string   `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid    string   `json:"groupJid" validate:"required"`
+	Description string   `json:"description,omitempty"`
+	Numbers     []string `json:"numbers" validate:"required,min=1,dive,required"`
+}
+
+type GroupUpdateParticipantRequest struct {
+	InstanceID   string   `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid     string   `json:"groupJid" validate:"required"`
+	Action       string   `json:"action" validate:"required,oneof=add remove promote demote"`
+	Participants []string `json:"participants" validate:"required,min=1,dive,required"`
+}
+
+type GroupUpdateSettingRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+	Action     string `json:"action" validate:"required,oneof=announcement not_announcement locked unlocked"`
+}
+
+type GroupToggleEphemeralRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+	Expiration uint32 `json:"expiration" validate:"oneof=0 86400 604800 7776000"`
+}
+
+type GroupRevokeInviteRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+}
+
+type GroupLeaveRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `query:"groupJid" validate:"required"`
+}

--- a/server/routes/community.go
+++ b/server/routes/community.go
@@ -1,0 +1,25 @@
+package routes
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/repositories/instances"
+	"github.com/verbeux-ai/whatsmiau/server/controllers"
+	"github.com/verbeux-ai/whatsmiau/services"
+)
+
+func Community(group *echo.Group) {
+	redisInstance := instances.NewRedis(services.Redis())
+	controller := controllers.NewCommunities(redisInstance, whatsmiau.Get())
+
+	group.POST("/create", controller.CreateCommunity)
+	group.POST("/createSubGroup", controller.CreateSubGroup)
+	group.POST("/linkGroup", controller.LinkGroup)
+	group.POST("/unlinkGroup", controller.UnlinkGroup)
+	group.GET("/subGroups", controller.SubGroups)
+	group.GET("/linkedGroupsParticipants", controller.LinkedGroupsParticipants)
+	group.POST("/setJoinApprovalMode", controller.SetJoinApprovalMode)
+	group.POST("/setMemberAddMode", controller.SetMemberAddMode)
+	group.GET("/requestParticipants", controller.RequestParticipants)
+	group.POST("/requestParticipants/update", controller.UpdateRequestParticipants)
+}

--- a/server/routes/group.go
+++ b/server/routes/group.go
@@ -1,0 +1,54 @@
+package routes
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/repositories/instances"
+	"github.com/verbeux-ai/whatsmiau/server/controllers"
+	"github.com/verbeux-ai/whatsmiau/services"
+)
+
+func Group(group *echo.Group) {
+	redisInstance := instances.NewRedis(services.Redis())
+	controller := controllers.NewGroups(redisInstance, whatsmiau.Get())
+
+	group.POST("/create", controller.CreateGroup)
+	group.POST("/updateGroupSubject", controller.UpdateGroupSubject)
+	group.POST("/updateGroupPicture", controller.UpdateGroupPicture)
+	group.POST("/updateGroupDescription", controller.UpdateGroupDescription)
+	group.GET("/findGroupInfos", controller.FindGroupInfos)
+	group.GET("/fetchAllGroups", controller.FetchAllGroups)
+	group.GET("/participants", controller.FindParticipants)
+	group.GET("/inviteCode", controller.InviteCode)
+	group.GET("/inviteInfo", controller.InviteInfo)
+	group.GET("/acceptInviteCode", controller.AcceptInviteCode)
+	group.POST("/sendInvite", controller.SendInvite)
+	group.POST("/revokeInviteCode", controller.RevokeInviteCode)
+	group.POST("/updateParticipant", controller.UpdateParticipant)
+	group.POST("/updateSetting", controller.UpdateSetting)
+	group.POST("/toggleEphemeral", controller.ToggleEphemeral)
+	group.DELETE("/leaveGroup", controller.LeaveGroup)
+}
+
+func GroupEVO(group *echo.Group) {
+	redisInstance := instances.NewRedis(services.Redis())
+	controller := controllers.NewGroups(redisInstance, whatsmiau.Get())
+
+	// Evolution API Compatibility
+	group.POST("/create/:instance", controller.CreateGroup)
+	group.POST("/updateGroupSubject/:instance", controller.UpdateGroupSubject)
+	group.POST("/updateGroupPicture/:instance", controller.UpdateGroupPicture)
+	group.POST("/updateGroupDescription/:instance", controller.UpdateGroupDescription)
+	group.GET("/findGroupInfos/:instance", controller.FindGroupInfos)
+	group.GET("/fetchAllGroups/:instance", controller.FetchAllGroups)
+	group.GET("/participants/:instance", controller.FindParticipants)
+	group.GET("/inviteCode/:instance", controller.InviteCode)
+	group.GET("/inviteInfo/:instance", controller.InviteInfo)
+	group.GET("/acceptInviteCode/:instance", controller.AcceptInviteCode)
+	group.POST("/sendInvite/:instance", controller.SendInvite)
+	group.POST("/revokeInviteCode/:instance", controller.RevokeInviteCode)
+	group.POST("/updateParticipant/:instance", controller.UpdateParticipant)
+	group.POST("/updateSetting/:instance", controller.UpdateSetting)
+	group.POST("/toggleEphemeral/:instance", controller.ToggleEphemeral)
+	group.DELETE("/leaveGroup/:instance", controller.LeaveGroup)
+}

--- a/server/routes/main.go
+++ b/server/routes/main.go
@@ -28,8 +28,11 @@ func V1(group *echo.Group) {
 	Instance(group.Group("/instance"))
 	Message(group.Group("/instance/:instance/message"))
 	Chat(group.Group("/instance/:instance/chat"))
+	Group(group.Group("/instance/:instance/group"))
+	Community(group.Group("/instance/:instance/community"))
 
 	ChatEVO(group.Group("/chat"))
 	MessageEVO(group.Group("/message"))
+	GroupEVO(group.Group("/group"))
 	Webhook(group.Group("/webhook"))
 }

--- a/tests/integration/community_test.go
+++ b/tests/integration/community_test.go
@@ -1,0 +1,223 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommunityFlow testa o ciclo de vida completo de uma comunidade:
+// criação, subgrupos, link/unlink, configurações de join e participantes.
+func TestCommunityFlow(t *testing.T) {
+	var communityJID string
+	var subGroupJID string
+
+	t.Run("CreateCommunity", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "create"), map[string]any{
+			"subject":     "WhatsMiau Community Test",
+			"description": "Comunidade de testes automatizados",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		jid, _ := body["id"].(string)
+		require.NotEmpty(t, jid, "resposta deve conter o campo 'id'")
+		communityJID = jid
+
+		isCommunity, _ := body["isCommunity"].(bool)
+		assert.True(t, isCommunity, "isCommunity deve ser true para comunidades")
+	})
+
+	if communityJID == "" {
+		t.Skip("CreateCommunity falhou — pulando testes dependentes")
+	}
+
+	cooldown() // evita rate-limit ao criar subgrupo logo após a comunidade
+
+	t.Run("CreateSubGroup", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "createSubGroup"), map[string]any{
+			"subject":      "Subgrupo de Teste",
+			"parentJid":    communityJID,
+			"participants": []string{},
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		jid, _ := body["id"].(string)
+		require.NotEmpty(t, jid, "resposta deve conter o campo 'id' do subgrupo")
+		subGroupJID = jid
+	})
+
+	t.Run("SubGroups", func(t *testing.T) {
+		resp := do(t, http.MethodGet, communityURLQuery(t, "subGroups", "communityJid="+communityJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var groups []map[string]any
+		mustDecode(t, resp, &groups)
+		require.NotEmpty(t, groups, "comunidade deve ter ao menos o grupo de anúncios")
+	})
+
+	t.Run("LinkedGroupsParticipants", func(t *testing.T) {
+		resp := do(t, http.MethodGet,
+			communityURLQuery(t, "linkedGroupsParticipants", "communityJid="+communityJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	// SetJoinApprovalMode e SetMemberAddMode aplicam-se a subgrupos, não ao parent da comunidade.
+	// Usamos subGroupJID quando disponível; caso contrário o sub-teste é pulado.
+	t.Run("SetJoinApprovalMode_True", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando SetJoinApprovalMode")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "setJoinApprovalMode"), map[string]any{
+			"communityJid": subGroupJID,
+			"mode":         true,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("SetJoinApprovalMode_False", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando SetJoinApprovalMode")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "setJoinApprovalMode"), map[string]any{
+			"communityJid": subGroupJID,
+			"mode":         false,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("SetMemberAddMode_AdminOnly", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando SetMemberAddMode")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "setMemberAddMode"), map[string]any{
+			"communityJid": subGroupJID,
+			"mode":         "admin_add",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("SetMemberAddMode_AllMembers", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando SetMemberAddMode")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "setMemberAddMode"), map[string]any{
+			"communityJid": subGroupJID,
+			"mode":         "all_member_add",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("RequestParticipants", func(t *testing.T) {
+		resp := do(t, http.MethodGet,
+			communityURLQuery(t, "requestParticipants", "communityJid="+communityJID), nil)
+		defer drainClose(resp)
+		// 200 com lista vazia ou com pedidos pendentes
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("UnlinkSubGroup", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando UnlinkSubGroup")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "unlinkGroup"), map[string]any{
+			"parentJid": communityJID,
+			"childJid":  subGroupJID,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("LinkGroup", func(t *testing.T) {
+		if subGroupJID == "" {
+			t.Skip("CreateSubGroup falhou — pulando LinkGroup")
+		}
+		resp := do(t, http.MethodPost, communityURL(t, "linkGroup"), map[string]any{
+			"parentJid": communityJID,
+			"childJid":  subGroupJID,
+		})
+		defer drainClose(resp)
+		// 200 se linkado com sucesso; 403 se instância não é admin (aceitável)
+		assert.True(t, resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusForbidden,
+			"linkGroup deve retornar 200 ou 403, got %d", resp.StatusCode)
+	})
+}
+
+
+// TestCommunityValidation cobre rejeições esperadas nos endpoints de comunidade.
+func TestCommunityValidation(t *testing.T) {
+	t.Run("CreateCommunity_MissingSubject", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "create"), map[string]any{
+			"description": "sem subject",
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("CreateSubGroup_MissingParentJid", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "createSubGroup"), map[string]any{
+			"subject":      "Sub sem parent",
+			"participants": []string{},
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("CreateSubGroup_InvalidParentJid", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "createSubGroup"), map[string]any{
+			"subject":      "Sub com jid inválido",
+			"parentJid":    "nao-e-um-jid@s.whatsapp.net",
+			"participants": []string{},
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("LinkGroup_MissingChildJid", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "linkGroup"), map[string]any{
+			"parentJid": "123456789@g.us",
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("SetMemberAddMode_InvalidMode", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "setMemberAddMode"), map[string]any{
+			"communityJid": "123456789@g.us",
+			"mode":         "everyone",
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("UpdateRequestParticipants_InvalidAction", func(t *testing.T) {
+		resp := do(t, http.MethodPost, communityURL(t, "requestParticipants/update"), map[string]any{
+			"communityJid": "123456789@g.us",
+			"action":       "ignore",
+			"participants": []string{"5511999999999"},
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("SubGroups_MissingCommunityJid", func(t *testing.T) {
+		resp := do(t, http.MethodGet, communityURL(t, "subGroups"), nil)
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/tests/integration/group_test.go
+++ b/tests/integration/group_test.go
@@ -1,0 +1,356 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupFlow testa o ciclo de vida completo de um grupo: criação, consulta,
+// atualização de metadados, convite, configurações e saída.
+// Cada sub-teste depende do estado gerado pelo anterior; se um falhar,
+// os seguintes são pulados via t.SkipNow() para evitar falsos negativos.
+func TestGroupFlow(t *testing.T) {
+	var groupJID string
+
+	t.Run("CreateGroup", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "create"), map[string]any{
+			"subject":      "WhatsMiau Test",
+			"participants": []string{},
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		jid, _ := body["id"].(string)
+		require.NotEmpty(t, jid, "resposta deve conter o campo 'id' com o JID do grupo")
+		groupJID = jid
+		assert.Equal(t, true, body["isCommunity"] == false || body["isCommunity"] == nil)
+	})
+
+	if groupJID == "" {
+		t.Skip("CreateGroup falhou — pulando testes dependentes")
+	}
+
+	t.Run("FindGroupInfos", func(t *testing.T) {
+		resp := do(t, http.MethodGet, groupURLQuery(t, "findGroupInfos", "groupJid="+groupJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		assert.Equal(t, groupJID, body["id"])
+		assert.Equal(t, "WhatsMiau Test", body["subject"])
+		assert.NotNil(t, body["participants"])
+	})
+
+	t.Run("FetchAllGroups", func(t *testing.T) {
+		resp := do(t, http.MethodGet, groupURLQuery(t, "fetchAllGroups", "getParticipants=false"), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var groups []map[string]any
+		mustDecode(t, resp, &groups)
+		require.NotEmpty(t, groups)
+
+		found := false
+		for _, g := range groups {
+			if g["id"] == groupJID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "grupo criado deve aparecer em fetchAllGroups")
+	})
+
+	t.Run("FindParticipants", func(t *testing.T) {
+		resp := do(t, http.MethodGet, groupURLQuery(t, "participants", "groupJid="+groupJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		_, ok := body["participants"]
+		assert.True(t, ok, "resposta deve conter o campo 'participants'")
+	})
+
+	t.Run("UpdateGroupSubject", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupSubject"), map[string]any{
+			"groupJid": groupJID,
+			"subject":  "WhatsMiau Test Atualizado",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		// confirma que o nome foi alterado
+		check := do(t, http.MethodGet, groupURLQuery(t, "findGroupInfos", "groupJid="+groupJID), nil)
+		var info map[string]any
+		mustDecode(t, check, &info)
+		assert.Equal(t, "WhatsMiau Test Atualizado", info["subject"])
+	})
+
+	t.Run("UpdateGroupDescription", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupDescription"), map[string]any{
+			"groupJid":    groupJID,
+			"description": "Grupo de testes automatizados do WhatsMiau",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("InviteCode", func(t *testing.T) {
+		resp := do(t, http.MethodGet, groupURLQuery(t, "inviteCode", "groupJid="+groupJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		assert.NotEmpty(t, body["inviteCode"])
+		assert.NotEmpty(t, body["inviteUrl"])
+	})
+
+	t.Run("InviteInfo", func(t *testing.T) {
+		// Busca o invite code atual
+		codeResp := do(t, http.MethodGet, groupURLQuery(t, "inviteCode", "groupJid="+groupJID), nil)
+		var codeBody map[string]any
+		mustDecode(t, codeResp, &codeBody)
+		code, _ := codeBody["inviteCode"].(string)
+		require.NotEmpty(t, code)
+
+		resp := do(t, http.MethodGet, groupURLQuery(t, "inviteInfo", "inviteCode="+code), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		assert.Equal(t, groupJID, body["id"])
+	})
+
+	t.Run("RevokeInviteCode", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "revokeInviteCode"), map[string]any{
+			"groupJid": groupJID,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		assert.NotEmpty(t, body["inviteCode"], "deve retornar o novo código de convite")
+		assert.NotEmpty(t, body["inviteUrl"])
+	})
+
+	t.Run("UpdateSettingAnnouncement", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateSetting"), map[string]any{
+			"groupJid": groupJID,
+			"action":   "announcement",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		// Reverte para modo normal
+		revert := do(t, http.MethodPost, groupURL(t, "updateSetting"), map[string]any{
+			"groupJid": groupJID,
+			"action":   "not_announcement",
+		})
+		drainClose(revert)
+	})
+
+	t.Run("UpdateSettingLocked", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateSetting"), map[string]any{
+			"groupJid": groupJID,
+			"action":   "locked",
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		revert := do(t, http.MethodPost, groupURL(t, "updateSetting"), map[string]any{
+			"groupJid": groupJID,
+			"action":   "unlocked",
+		})
+		drainClose(revert)
+	})
+
+	t.Run("ToggleEphemeral", func(t *testing.T) {
+		// Ativa mensagens temporárias de 24h
+		resp := do(t, http.MethodPost, groupURL(t, "toggleEphemeral"), map[string]any{
+			"groupJid":   groupJID,
+			"expiration": 86400,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		// Desativa
+		revert := do(t, http.MethodPost, groupURL(t, "toggleEphemeral"), map[string]any{
+			"groupJid":   groupJID,
+			"expiration": 0,
+		})
+		drainClose(revert)
+	})
+
+	t.Run("LeaveGroup", func(t *testing.T) {
+		resp := do(t, http.MethodDelete, groupURLQuery(t, "leaveGroup", "groupJid="+groupJID), nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Verificar que findGroupInfos retorna 4xx (não 500) após sair
+		check := do(t, http.MethodGet, groupURLQuery(t, "findGroupInfos", "groupJid="+groupJID), nil)
+		drainClose(check)
+		assert.True(t, check.StatusCode >= 400 && check.StatusCode < 500,
+			"findGroupInfos após LeaveGroup deve retornar 4xx, got %d", check.StatusCode)
+	})
+}
+
+// TestGroupUpdateParticipant testa add/remove/promote/demote de participantes.
+// Requer TEST_PARTICIPANT_NUMBER definida.
+func TestGroupUpdateParticipant(t *testing.T) {
+	number := participantNumber()
+	if number == "" {
+		t.Skip("TEST_PARTICIPANT_NUMBER não definida — pulando testes de participantes")
+	}
+
+	// Cria grupo com o participante
+	createResp := do(t, http.MethodPost, groupURL(t, "create"), map[string]any{
+		"subject":      "WhatsMiau Partic Test",
+		"participants": []string{number},
+	})
+	var created map[string]any
+	mustDecode(t, createResp, &created)
+	groupJID, _ := created["id"].(string)
+	require.NotEmpty(t, groupJID)
+
+	t.Cleanup(func() {
+		resp := do(t, http.MethodDelete, groupURLQuery(t, "leaveGroup", "groupJid="+groupJID), nil)
+		drainClose(resp)
+	})
+
+	for _, tc := range []struct {
+		name   string
+		action string
+	}{
+		{"Promote", "promote"},
+		{"Demote", "demote"},
+		{"Remove", "remove"},
+		{"Add", "add"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp := do(t, http.MethodPost, groupURL(t, "updateParticipant"), map[string]any{
+				"groupJid":     groupJID,
+				"action":       tc.action,
+				"participants": []string{number},
+			})
+			defer drainClose(resp)
+			require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+			var body map[string]any
+			mustDecode(t, resp, &body)
+			assert.NotNil(t, body["participants"])
+		})
+	}
+}
+
+// TestGroupSendInvite testa o envio de convite para um número externo.
+// Requer TEST_PARTICIPANT_NUMBER definida.
+func TestGroupSendInvite(t *testing.T) {
+	number := participantNumber()
+	if number == "" {
+		t.Skip("TEST_PARTICIPANT_NUMBER não definida — pulando testes de envio de convite")
+	}
+
+	// Cria grupo temporário
+	createResp := do(t, http.MethodPost, groupURL(t, "create"), map[string]any{
+		"subject":      "WhatsMiau Invite Test",
+		"participants": []string{},
+	})
+	var created map[string]any
+	mustDecode(t, createResp, &created)
+	groupJID, _ := created["id"].(string)
+	require.NotEmpty(t, groupJID)
+
+	t.Cleanup(func() {
+		resp := do(t, http.MethodDelete, groupURLQuery(t, "leaveGroup", "groupJid="+groupJID), nil)
+		drainClose(resp)
+	})
+
+	resp := do(t, http.MethodPost, groupURL(t, "sendInvite"), map[string]any{
+		"groupJid":    groupJID,
+		"description": "Convite de teste automatizado",
+		"numbers":     []string{number},
+	})
+	defer drainClose(resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	mustDecode(t, resp, &body)
+	assert.NotEmpty(t, body["inviteUrl"])
+	assert.NotNil(t, body["sent"])
+}
+
+// TestGroupValidation cobre rejeições esperadas sem precisar de instância conectada.
+func TestGroupValidation(t *testing.T) {
+	t.Run("CreateGroup_MissingSubject", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "create"), map[string]any{
+			"participants": []string{},
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("FindGroupInfos_InvalidJID", func(t *testing.T) {
+		// JID com servidor de usuário (@s.whatsapp.net) em vez de grupo (@g.us)
+		resp := do(t, http.MethodGet, groupURLQuery(t, "findGroupInfos", "groupJid=5511999999999%40s.whatsapp.net"), nil)
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("UpdateParticipant_InvalidAction", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateParticipant"), map[string]any{
+			"groupJid":     "123456789@g.us",
+			"action":       "kick",
+			"participants": []string{"5511999999999"},
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("UpdateSetting_InvalidAction", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateSetting"), map[string]any{
+			"groupJid": "123456789@g.us",
+			"action":   "silent",
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("ToggleEphemeral_InvalidExpiration", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "toggleEphemeral"), map[string]any{
+			"groupJid":   "123456789@g.us",
+			"expiration": 999,
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("UpdateGroupSubject_MissingGroupJid", func(t *testing.T) {
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupSubject"), map[string]any{
+			"subject": "Test",
+		})
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("FindGroupInfos_NotConnectedInstance", func(t *testing.T) {
+		// Usa ID de instância que sabidamente não existe
+		path := fmt.Sprintf("/v1/instance/%s/group/findGroupInfos?groupJid=123456789@g.us",
+			"instance-que-nao-existe-xyz")
+		resp := do(t, http.MethodGet, path, nil)
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// cooldown aguarda entre operações que criam grupos para evitar rate-limit do WhatsApp.
+func cooldown() { time.Sleep(3 * time.Second) }
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+func baseURL() string {
+	if u := os.Getenv("TEST_BASE_URL"); u != "" {
+		return u
+	}
+	return "http://localhost:8080"
+}
+
+func apiKey() string {
+	return os.Getenv("TEST_API_KEY")
+}
+
+// instanceID retorna TEST_INSTANCE_ID e falha o teste se não estiver definida.
+func instanceID(t *testing.T) string {
+	t.Helper()
+	id := os.Getenv("TEST_INSTANCE_ID")
+	require.NotEmpty(t, id, "TEST_INSTANCE_ID deve estar definida para testes de integração")
+	return id
+}
+
+// participantNumber retorna TEST_PARTICIPANT_NUMBER (opcional).
+// Testes que dependem desse valor devem chamar t.Skip se estiver vazio.
+func participantNumber() string {
+	return os.Getenv("TEST_PARTICIPANT_NUMBER")
+}
+
+// do executa uma requisição HTTP com auth e Content-Type configurados.
+func do(t *testing.T, method, path string, body any) *http.Response {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		r = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, baseURL()+path, r)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if k := apiKey(); k != "" {
+		req.Header.Set("apikey", k)
+	}
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// mustDecode decodifica o body JSON da resposta em out.
+func mustDecode(t *testing.T, resp *http.Response, out any) {
+	t.Helper()
+	defer resp.Body.Close()
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(out))
+}
+
+// drainClose descarta e fecha o body da resposta.
+func drainClose(resp *http.Response) {
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+	resp.Body.Close()
+}
+
+func groupURL(t *testing.T, action string) string {
+	return fmt.Sprintf("/v1/instance/%s/group/%s", instanceID(t), action)
+}
+
+func groupURLQuery(t *testing.T, action, query string) string {
+	return fmt.Sprintf("/v1/instance/%s/group/%s?%s", instanceID(t), action, query)
+}
+
+func communityURL(t *testing.T, action string) string {
+	return fmt.Sprintf("/v1/instance/%s/community/%s", instanceID(t), action)
+}
+
+func communityURLQuery(t *testing.T, action, query string) string {
+	return fmt.Sprintf("/v1/instance/%s/community/%s?%s", instanceID(t), action, query)
+}


### PR DESCRIPTION
## Summary

Adiciona suporte completo a gerenciamento de **grupos** e **comunidades** WhatsApp via API, mantendo compatibilidade com Evolution API.

### Group (16 endpoints)
- **Metadata**: `create`, `updateGroupSubject`, `updateGroupPicture`, `updateGroupDescription`
- **Consultas**: `findGroupInfos`, `fetchAllGroups`, `participants`
- **Invites**: `inviteCode`, `inviteInfo`, `acceptInviteCode`, `sendInvite`, `revokeInviteCode`
- **Admin**: `updateParticipant` (add/remove/promote/demote), `updateSetting` (announce/locked), `toggleEphemeral`, `leaveGroup`

Rotas em `/v1/instance/:instance/group/...` e versão Evolution-compat em `/v1/group/.../:instance`.

### Community (10 endpoints)
- **Estrutura**: `create`, `createSubGroup`, `linkGroup`, `unlinkGroup`, `subGroups`, `linkedGroupsParticipants`
- **Moderação**: `setJoinApprovalMode`, `setMemberAddMode`, `requestParticipants` (listar/aprovar/rejeitar)

### Extras
- Helper `parseGroupJID` em `server/controllers/helper.go`
- Mapeamento de erros whatsmeow → HTTP (404 / 403 / 410 / 429 etc) via `mapGroupError`
- Validação de subject limitado a 25 caracteres (limite WhatsApp)
- Swagger atualizado (docs.go / swagger.json / swagger.yaml)
- Testes de integração em `tests/integration/` (group + community)

## Test plan
- [ ] `go build ./...` passa
- [ ] Rodar testes de integração contra instância real (`tests/integration/`)
- [ ] Validar criação de grupo + atualização de participantes
- [ ] Validar criação de comunidade + linkar subgrupo
- [ ] Verificar swagger em `/swagger/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)