### PR TITLE
feat: add restart instance endpoint

### DIFF
--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -1,6 +1,7 @@
 package whatsmiau
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -512,6 +513,49 @@ func (s *Whatsmiau) Disconnect(id string) error {
 	client.Disconnect()
 	s.qrCache.Delete(id)
 	s.pairingCache.Delete(id)
+	return nil
+}
+
+func (s *Whatsmiau) Restart(ctx context.Context, id string) error {
+	lock, _ := s.lockConnection.LoadOrStore(id, &sync.Mutex{})
+	lock.Lock()
+	defer lock.Unlock()
+
+	oldClient, ok := s.clients.Load(id)
+	if !ok {
+		return fmt.Errorf("instance %s is not connected", id)
+	}
+
+	device := oldClient.Store
+	oldClient.RemoveEventHandlers()
+	oldClient.Disconnect()
+	s.clients.Delete(id)
+
+	if device == nil || device.ID == nil {
+		return fmt.Errorf("instance %s has no device store", id)
+	}
+
+	s.qrCache.Delete(id)
+	s.pairingCache.Delete(id)
+	s.observerRunning.Delete(id)
+	s.instanceCache.Delete(id)
+
+	instance := s.getInstance(id)
+	if instance == nil {
+		return fmt.Errorf("instance %s not found in redis", id)
+	}
+
+	client := whatsmeow.NewClient(device, s.logger)
+	configProxy(client, instance.InstanceProxy)
+	client.AddEventHandler(s.Handle(id))
+	s.clients.Store(id, client)
+
+	if err := client.Connect(); err != nil {
+		zap.L().Error("restart: connect failed", zap.String("id", id), zap.Error(err))
+		return err
+	}
+
+	zap.L().Info("restart: instance restarted successfully", zap.String("id", id))
 	return nil
 }
 

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"net/http"
 
@@ -438,5 +439,60 @@ func (s *Instance) Delete(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusOK, dto.DeleteInstanceResponse{
 		Message: "instance deleted",
+	})
+}
+
+// Restart godoc
+// @Summary      Restart an instance connection
+// @Description  Disconnects and reconnects the WhatsApp websocket without logging out
+// @Tags         Instance
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        id  path  string  true  "Instance ID"
+// @Success      200  {object}  dto.RestartInstanceResponse
+// @Failure      400  {object}  utils.HTTPErrorResponse
+// @Failure      404  {object}  utils.HTTPErrorResponse
+// @Failure      422  {object}  utils.HTTPErrorResponse
+// @Failure      500  {object}  utils.HTTPErrorResponse
+// @Router       /instance/{id}/restart [post]
+// @Router       /instance/restart/{id} [post]
+func (s *Instance) Restart(ctx echo.Context) error {
+	c := ctx.Request().Context()
+	var request dto.RestartInstanceRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	result, err := s.repo.List(c, request.ID)
+	if err != nil {
+		zap.L().Error("failed to list instances", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to list instances")
+	}
+	if len(result) == 0 {
+		return utils.HTTPFail(ctx, http.StatusNotFound, nil, "instance not found")
+	}
+
+	currentStatus, err := s.whatsmiau.Status(request.ID)
+	if err != nil {
+		zap.L().Error("failed to get instance status", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to get instance status")
+	}
+	if currentStatus != whatsmiau.Connected && currentStatus != whatsmiau.Connecting {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil,
+			fmt.Sprintf("instance must be connected or connecting, current state: %s", currentStatus))
+	}
+
+	if err := s.whatsmiau.Restart(c, request.ID); err != nil {
+		zap.L().Error("failed to restart instance", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to restart instance")
+	}
+
+	return ctx.JSON(http.StatusOK, dto.RestartInstanceResponse{
+		ID:     request.ID,
+		Status: string(whatsmiau.Connecting),
+		Instance: &dto.RestartInstanceEvoCompatibility{
+			InstanceName: request.ID,
+			Status:       string(whatsmiau.Connecting),
+		},
 	})
 }

--- a/server/dto/instance.go
+++ b/server/dto/instance.go
@@ -110,3 +110,18 @@ type LogoutInstanceRequest struct {
 type LogoutInstanceResponse struct {
 	Message string `json:"message,omitempty"`
 }
+
+type RestartInstanceRequest struct {
+	ID string `param:"id" validate:"required" swaggerignore:"true"`
+}
+
+type RestartInstanceResponse struct {
+	ID       string                          `json:"id,omitempty"`
+	Status   string                          `json:"state,omitempty"`
+	Instance *RestartInstanceEvoCompatibility `json:"instance,omitempty"`
+}
+
+type RestartInstanceEvoCompatibility struct {
+	InstanceName string `json:"instanceName,omitempty"`
+	Status       string `json:"status,omitempty"`
+}

--- a/server/routes/instance.go
+++ b/server/routes/instance.go
@@ -18,6 +18,7 @@ func Instance(group *echo.Group) {
 	group.POST("/:id/logout", controller.Logout)
 	group.DELETE("/:id", controller.Delete)
 	group.GET("/:id/status", controller.Status)
+	group.POST("/:id/restart", controller.Restart)
 
 	// Evolution API Compatibility (partially REST)
 	group.POST("/create", controller.Create)
@@ -28,5 +29,6 @@ func Instance(group *echo.Group) {
 	group.DELETE("/logout/:id", controller.Logout)
 	group.DELETE("/delete/:id", controller.Delete)
 	group.PUT("/update/:id", controller.Update)
+	group.POST("/restart/:id", controller.Restart)
 
 }

--- a/tests/integration/restart_test.go
+++ b/tests/integration/restart_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestartInstance(t *testing.T) {
+	id := instanceID(t)
+
+	t.Run("RestartConnectedInstance", func(t *testing.T) {
+		statusResp := do(t, http.MethodGet, "/v1/instance/"+id+"/status", nil)
+		defer drainClose(statusResp)
+		require.Equal(t, http.StatusOK, statusResp.StatusCode)
+
+		var statusBody map[string]any
+		mustDecode(t, statusResp, &statusBody)
+		state, _ := statusBody["state"].(string)
+		if state != "open" {
+			t.Skipf("instance not connected (state=%s), skipping restart test", state)
+		}
+
+		resp := do(t, http.MethodPost, "/v1/instance/"+id+"/restart", nil)
+		defer drainClose(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		mustDecode(t, resp, &body)
+		assert.Equal(t, id, body["id"])
+		assert.Equal(t, "connecting", body["state"])
+
+		inst, ok := body["instance"].(map[string]any)
+		require.True(t, ok, "response must contain 'instance' field")
+		assert.Equal(t, id, inst["instanceName"])
+		assert.Equal(t, "connecting", inst["status"])
+	})
+
+	t.Run("RestartNonExistentInstance", func(t *testing.T) {
+		resp := do(t, http.MethodPost, "/v1/instance/non-existent-xyz/restart", nil)
+		defer drainClose(resp)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("RestartEvoRoute", func(t *testing.T) {
+		resp := do(t, http.MethodPost, "/v1/instance/restart/"+id, nil)
+		defer drainClose(resp)
+		assert.True(t, resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusBadRequest,
+			"expected 200 or 400, got %d", resp.StatusCode)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `POST /v1/instance/:id/restart` (native) and `POST /v1/instance/restart/:id` (Evolution API compat) endpoint
- Implements `Restart()` method on the Whatsmiau core that disconnects, reloads Redis data, and reconnects preserving the device session in SQL
- Includes integration tests and full error handling (instance not found, wrong state, device missing)

## How it works
The restart flow:
1. Validates instance exists in Redis and is in connected/connecting state
2. Removes event handlers, disconnects websocket, removes from clients map
3. Preserves the device store reference (credentials stay in SQL — no logout)
4. Clears connection caches (QR, pairing, observer, instanceCache)
5. Reloads fresh instance metadata from Redis (webhook, proxy config)
6. Creates a new whatsmeow client with the same device
7. Configures proxy, registers event handlers, reconnects websocket

## Test plan
- `go build ./...` — compiles without errors
- `go vet ./...` — no issues
- `go test -tags=integration -c ./tests/integration/` — test binary compiles
- Integration test: `TEST_INSTANCE_ID=xxx TEST_API_KEY=xxx go test -tags=integration ./tests/integration/ -run TestRestartInstance -v`

🤖 Generated with Verboo Code