### PR TITLE
fix: allow restart on closed instances

### DIFF
--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -15,6 +15,7 @@ import (
 	"github.com/verbeux-ai/whatsmiau/repositories/instances"
 	"github.com/verbeux-ai/whatsmiau/services"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
 	waLog "go.mau.fi/whatsmeow/util/log"
@@ -521,28 +522,51 @@ func (s *Whatsmiau) Restart(ctx context.Context, id string) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	oldClient, ok := s.clients.Load(id)
-	if !ok {
-		return fmt.Errorf("instance %s is not connected", id)
+	// Load fresh instance from Redis BEFORE destructive ops
+	ctxInst, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	instances, err := s.repo.List(ctxInst, id)
+	if err != nil {
+		return fmt.Errorf("failed to load instance %s: %w", id, err)
+	}
+	if len(instances) == 0 {
+		return fmt.Errorf("instance %s not found in redis", id)
+	}
+	instance := &instances[0]
+
+	// Clean up existing client
+	oldClient, hadClient := s.clients.Load(id)
+	if hadClient {
+		oldClient.RemoveEventHandlers()
+		oldClient.Disconnect()
+		s.clients.Delete(id)
 	}
 
-	device := oldClient.Store
-	oldClient.RemoveEventHandlers()
-	oldClient.Disconnect()
-	s.clients.Delete(id)
-
-	if device == nil || device.ID == nil {
-		return fmt.Errorf("instance %s has no device store", id)
-	}
-
+	// Clear caches
 	s.qrCache.Delete(id)
 	s.pairingCache.Delete(id)
 	s.observerRunning.Delete(id)
 	s.instanceCache.Delete(id)
 
-	instance := s.getInstance(id)
-	if instance == nil {
-		return fmt.Errorf("instance %s not found in redis", id)
+	// Find device: old client's Store, or scan SQL store
+	var device *store.Device
+	if hadClient && oldClient.Store != nil && oldClient.Store.ID != nil {
+		device = oldClient.Store
+	} else if instance.RemoteJID != "" {
+		devices, err := s.container.GetAllDevices(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list devices: %w", err)
+		}
+		for _, d := range devices {
+			if d.ID != nil && d.ID.String() == instance.RemoteJID {
+				device = d
+				break
+			}
+		}
+	}
+
+	if device == nil {
+		return fmt.Errorf("instance %s has no saved session — connect via QR code first", id)
 	}
 
 	client := whatsmeow.NewClient(device, s.logger)

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"math/rand/v2"
 	"net/http"
 
@@ -470,16 +469,6 @@ func (s *Instance) Restart(ctx echo.Context) error {
 	}
 	if len(result) == 0 {
 		return utils.HTTPFail(ctx, http.StatusNotFound, nil, "instance not found")
-	}
-
-	currentStatus, err := s.whatsmiau.Status(request.ID)
-	if err != nil {
-		zap.L().Error("failed to get instance status", zap.Error(err))
-		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to get instance status")
-	}
-	if currentStatus != whatsmiau.Connected && currentStatus != whatsmiau.Connecting {
-		return utils.HTTPFail(ctx, http.StatusBadRequest, nil,
-			fmt.Sprintf("instance must be connected or connecting, current state: %s", currentStatus))
 	}
 
 	if err := s.whatsmiau.Restart(c, request.ID); err != nil {

--- a/tests/integration/restart_test.go
+++ b/tests/integration/restart_test.go
@@ -49,7 +49,7 @@ func TestRestartInstance(t *testing.T) {
 	t.Run("RestartEvoRoute", func(t *testing.T) {
 		resp := do(t, http.MethodPost, "/v1/instance/restart/"+id, nil)
 		defer drainClose(resp)
-		assert.True(t, resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusBadRequest,
-			"expected 200 or 400, got %d", resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"expected 200, got %d", resp.StatusCode)
 	})
 }


### PR DESCRIPTION
## Summary
- Removes the state precondition (required `open` or `connecting`) from the restart endpoint — now accepts any state including `closed`
- Adds SQL store fallback: if the client is not in memory, scans `container.GetAllDevices()` by `RemoteJID` to reuse the device
- Eliminates panic risk: replaced `getInstance()` (which called `zap.L().Panic()`) with direct `repo.List()` call returning proper errors

## Key changes
| Before | After |
|--------|-------|
| State must be open/connecting | Any state accepted |
| `getInstance()` panics on Redis error | `repo.List()` returns error |
| Error if client not in `s.clients` | Falls back to SQL device scan |
| State checked in controller | No controller state check |

## Test plan
- `go build ./...` — compiles
- `go vet ./...` — no issues
- Integration test: `TEST_INSTANCE_ID=xxx TEST_API_KEY=xxx go test -tags=integration ./tests/integration/ -run TestRestartInstance -v`

🤖 Generated with Verboo Code