### PR TITLE
hotfix: propagate ctx and use GetDevice in restart

### DIFF
--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -523,7 +523,7 @@ func (s *Whatsmiau) Restart(ctx context.Context, id string) error {
 	defer lock.Unlock()
 
 	// Load fresh instance from Redis BEFORE destructive ops
-	ctxInst, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctxInst, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	instances, err := s.repo.List(ctxInst, id)
 	if err != nil {
@@ -553,15 +553,13 @@ func (s *Whatsmiau) Restart(ctx context.Context, id string) error {
 	if hadClient && oldClient.Store != nil && oldClient.Store.ID != nil {
 		device = oldClient.Store
 	} else if instance.RemoteJID != "" {
-		devices, err := s.container.GetAllDevices(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list devices: %w", err)
+		jid, parseErr := types.ParseJID(instance.RemoteJID)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse RemoteJID %s: %w", instance.RemoteJID, parseErr)
 		}
-		for _, d := range devices {
-			if d.ID != nil && d.ID.String() == instance.RemoteJID {
-				device = d
-				break
-			}
+		device, err = s.container.GetDevice(ctx, jid)
+		if err != nil {
+			return fmt.Errorf("failed to get device for %s: %w", instance.RemoteJID, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Addresses Gemini code review feedback on PR #57:

1. **Context propagation**: Use the caller's `ctx` instead of `context.Background()` for the Redis timeout context, so cancellation propagates correctly
2. **Efficiency**: Replace `container.GetAllDevices()` scan with `GetDevice(ctx, jid)` direct lookup by JID — O(1) instead of O(n)

## Changes
- `lib/whatsmiau/whatsmeow.go` — 2 lines changed: context.Background() → ctx, GetAllDevices scan → GetDevice lookup

🤖 Generated with Verboo Code