### PR TITLE
hotfix: nil pointer dereference on client.Store after proxy failure

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -522,7 +522,7 @@ func (s *Whatsmiau) handleConnectionUpdateEvent(id string, instance *models.Inst
 	}
 
 	if state == "open" {
-		if client, ok := s.clients.Load(id); ok && client.Store.ID != nil {
+		if client, ok := s.clients.Load(id); ok && client.Store != nil && client.Store.ID != nil {
 			data.Wuid = client.Store.ID.ToNonAD().String()
 			data.ProfileName = client.Store.PushName
 		}

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -376,7 +376,7 @@ func configProxy(client *whatsmeow.Client, instanceProxy models.InstanceProxy) {
 	}
 
 	var jid string
-	if client.Store.ID != nil {
+	if client.Store != nil && client.Store.ID != nil {
 		jid = client.Store.ID.String()
 	}
 

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -92,13 +92,21 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 			configProxy(client, instanceFound.InstanceProxy)
 			clients.Store(instanceFound.ID, client)
 			if err := client.Connect(); err != nil {
-				zap.L().Error("failed to connect connected device", zap.Error(err), zap.String("jid", client.Store.ID.String()))
+				jid := ""
+				if client.Store != nil && client.Store.ID != nil {
+					jid = client.Store.ID.String()
+				}
+				zap.L().Error("failed to connect connected device", zap.Error(err), zap.String("jid", jid))
 			}
 			continue
 		}
 
 		if err := client.Logout(context.TODO()); err != nil {
-			zap.L().Error("failed to logout", zap.Error(err), zap.String("jid", client.Store.ID.String()))
+			jid := ""
+			if client.Store != nil && client.Store.ID != nil {
+				jid = client.Store.ID.String()
+			}
+			zap.L().Error("failed to logout", zap.Error(err), zap.String("jid", jid))
 		}
 		if client.Store != nil && client.Store.ID != nil {
 			if err := container.DeleteDevice(context.Background(), client.Store); err != nil {


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference crash when `client.Connect()` fails through
an oxylabs proxy (Bad Gateway) and the error log tries to access
`client.Store.ID.String()` without nil check.

### Root cause

In `LoadMiau()`, when `configProxy(client, oxylabs)` is set and
`client.Connect()` returns Bad Gateway, the code at line 95 calls
`client.Store.ID.String()` for logging. A concurrent logout/conflict event
during the async connect can set Store.ID to nil, causing addr=0x20 crash.

The same pattern existed in 3 other locations.

### Files changed

- **lib/whatsmiau/whatsmeow.go**: Guard `client.Store.ID.String()` with
  `client.Store != nil && client.Store.ID != nil` in LoadMiau error paths
  (lines 95 and 101)
- **lib/whatsmiau/event_emitter.go**: Add `client.Store != nil` check in
  connection update handler (line 525)
- **lib/whatsmiau/helper.go**: Add `client.Store != nil` check in
  `configProxy()` (line 379)

🤖 Generated with Verboo Code