### PR TITLE
fix: accept valid international numbers shorter than 12 digits in numberToJid

### DIFF
--- a/server/controllers/helper.go
+++ b/server/controllers/helper.go
@@ -15,7 +15,11 @@ func numberToJid(number string) (*types.JID, error) {
 		number += "@s.whatsapp.net"
 	}
 
-	if len(splitNumber[0]) < 12 {
+	// E.164 numbers are 8-15 digits including the country code. The previous
+	// "< 12" bound only fit Brazilian numbers (55 + DDD + 8/9 = 12-13 digits)
+	// and wrongly rejected valid shorter international numbers that already
+	// carry their country prefix, e.g. US +1 (11 digits) and Spain +34 (11).
+	if len(splitNumber[0]) < 8 {
 		return nil, fmt.Errorf("invalid jid, put country prefix")
 	}
 

--- a/server/controllers/helper_test.go
+++ b/server/controllers/helper_test.go
@@ -1,0 +1,27 @@
+package controllers
+
+import "testing"
+
+func TestNumberToJidAcceptsInternationalNumbers(t *testing.T) {
+	validNumbers := []string{
+		"5561999211277", // Brazil (13 digits)
+		"13233923870",   // United States, +1 (11 digits)
+		"34662418782",   // Spain, +34 (11 digits)
+	}
+
+	for _, number := range validNumbers {
+		if _, err := numberToJid(number); err != nil {
+			t.Errorf("numberToJid(%q) returned unexpected error: %v", number, err)
+		}
+	}
+}
+
+func TestNumberToJidRejectsTooShortNumbers(t *testing.T) {
+	tooShort := []string{"123", "5561"}
+
+	for _, number := range tooShort {
+		if _, err := numberToJid(number); err == nil {
+			t.Errorf("numberToJid(%q) expected an error, got nil", number)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`numberToJid` (server/controllers/helper.go) rejects valid international numbers that already carry their country prefix:

```go
if len(splitNumber[0]) < 12 {
    return nil, fmt.Errorf("invalid jid, put country prefix")
}
```

The `< 12` bound only fits Brazilian numbers (`55` + DDD + 8/9 digits = 12-13). Legitimate shorter international numbers fail with the misleading "invalid jid, put country prefix" even though the prefix is present:

- US `+1 323 392 3870` -> `13233923870` (11 digits) -> rejected
- Spain `+34 662 418 782` -> `34662418782` (11 digits) -> rejected

## Fix

Lower the bound to the E.164 minimum (8 digits). E.164 numbers are 8-15 digits including the country code, so this lets valid shorter international numbers through while still rejecting clearly-truncated input.

## Test

Adds `server/controllers/helper_test.go`:
- accepts BR (13), US (11), ES (11)
- still rejects too-short input (`123`, `5561`)

I was unable to run `go test` in my environment (no Go toolchain available), so a CI run would be appreciated to confirm.
