### PR TITLE
feat: identify encCommentMessage in incoming messages instead of unknown

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -819,17 +819,16 @@ func (s *Whatsmiau) parseWAMessage(m *waE2E.Message) (string, *WookMessageRaw, *
 		ci = et.GetContextInfo()
 	} else if ec := m.GetEncCommentMessage(); ec != nil {
 		messageType = "encCommentMessage"
-		targetKey := ec.GetTargetMessageKey()
-		if targetKey != nil {
-			raw.EncCommentMessage = &WookEncCommentMessageRaw{
-				TargetMessageKey: &WookTargetMessageKey{
-					RemoteJid:   targetKey.GetRemoteJID(),
-					FromMe:      targetKey.GetFromMe(),
-					Id:          targetKey.GetID(),
-					Participant: targetKey.GetParticipant(),
-				},
-				EncPayload: ec.GetEncPayload(),
-				EncIv:      ec.GetEncIV(),
+		raw.EncCommentMessage = &WookEncCommentMessageRaw{
+			EncPayload: b64(ec.GetEncPayload()),
+			EncIv:      b64(ec.GetEncIV()),
+		}
+		if targetKey := ec.GetTargetMessageKey(); targetKey != nil {
+			raw.EncCommentMessage.TargetMessageKey = &WookKey{
+				RemoteJid:   targetKey.GetRemoteJID(),
+				FromMe:      targetKey.GetFromMe(),
+				Id:          targetKey.GetID(),
+				Participant: targetKey.GetParticipant(),
 			}
 		}
 	} else {
@@ -946,9 +945,9 @@ func (s *Whatsmiau) convertEventMessage(id string, instance *models.Instance, ev
 	m := e.Message
 
 	// Build the key
-	addressingMode := "jid"
-	if lid != "" {
-		addressingMode = "lid"
+	addressingMode := "lid"
+	if lid == "" {
+		addressingMode = "jid"
 	}
 	key := &WookKey{
 		RemoteJid:       jid,

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -817,6 +817,21 @@ func (s *Whatsmiau) parseWAMessage(m *waE2E.Message) (string, *WookMessageRaw, *
 		messageType = "conversation"
 		raw.Conversation = et.GetText()
 		ci = et.GetContextInfo()
+	} else if ec := m.GetEncCommentMessage(); ec != nil {
+		messageType = "encCommentMessage"
+		targetKey := ec.GetTargetMessageKey()
+		if targetKey != nil {
+			raw.EncCommentMessage = &WookEncCommentMessageRaw{
+				TargetMessageKey: &WookTargetMessageKey{
+					RemoteJid:   targetKey.GetRemoteJID(),
+					FromMe:      targetKey.GetFromMe(),
+					Id:          targetKey.GetID(),
+					Participant: targetKey.GetParticipant(),
+				},
+				EncPayload: ec.GetEncPayload(),
+				EncIv:      ec.GetEncIV(),
+			}
+		}
 	} else {
 		messageType = "unknown"
 	}
@@ -931,12 +946,17 @@ func (s *Whatsmiau) convertEventMessage(id string, instance *models.Instance, ev
 	m := e.Message
 
 	// Build the key
+	addressingMode := "jid"
+	if lid != "" {
+		addressingMode = "lid"
+	}
 	key := &WookKey{
-		RemoteJid:   jid,
-		RemoteLid:   lid,
-		FromMe:      e.Info.IsFromMe,
-		Id:          e.Info.ID,
-		Participant: senderJid,
+		RemoteJid:       jid,
+		RemoteLid:       lid,
+		FromMe:          e.Info.IsFromMe,
+		Id:              e.Info.ID,
+		Participant:     senderJid,
+		AddressingMode:  addressingMode,
 	}
 
 	// Determine status

--- a/lib/whatsmiau/models.go
+++ b/lib/whatsmiau/models.go
@@ -32,7 +32,7 @@ type WookMessageData struct {
 	PushName         string                  `json:"pushName,omitempty"`
 	Status           string                  `json:"status,omitempty"`
 	Message          *WookMessageRaw         `json:"message,omitempty"`
-	ContextInfo      *WookMessageContextInfo  `json:"contextInfo,omitempty"`
+	ContextInfo      *WookMessageContextInfo `json:"contextInfo,omitempty"`
 	MessageType      string                  `json:"messageType,omitempty"`
 	MessageTimestamp int                     `json:"messageTimestamp,omitempty"`
 	InstanceId       string                  `json:"instanceId,omitempty"`
@@ -84,11 +84,12 @@ type WookMessageExtendedTextMessageContextInfo struct {
 }
 
 type WookKey struct {
-	RemoteJid   string `json:"remoteJid,omitempty"`
-	RemoteLid   string `json:"remoteLid,omitempty"`
-	FromMe      bool   `json:"fromMe,omitempty"`
-	Id          string `json:"id,omitempty"`
-	Participant string `json:"participant,omitempty"`
+	RemoteJid      string `json:"remoteJid,omitempty"`
+	RemoteLid      string `json:"remoteLid,omitempty"`
+	FromMe         bool   `json:"fromMe,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Participant    string `json:"participant,omitempty"`
+	AddressingMode string `json:"addressingMode,omitempty"`
 }
 
 type WookMessageRaw struct {
@@ -110,6 +111,7 @@ type WookMessageRaw struct {
 	PollCreationMessage *WookPollCreationMessageRaw `json:"pollCreationMessage,omitempty"`
 	PollUpdateMessage   *WookPollUpdateMessageRaw   `json:"pollUpdateMessage,omitempty"`
 	PtvMessage          *WookPtvMessageRaw          `json:"ptvMessage,omitempty"`
+	EncCommentMessage   *WookEncCommentMessageRaw   `json:"encCommentMessage,omitempty"`
 	MediaURL            string                      `json:"mediaUrl,omitempty"` // Sent when connect with some storage
 }
 
@@ -173,6 +175,19 @@ type ReactionMessageRaw struct {
 	Key               *WookKey `json:"key,omitempty"`
 	Text              string   `json:"text,omitempty"`
 	SenderTimestampMs string   `json:"senderTimestampMs,omitempty"`
+}
+
+type WookTargetMessageKey struct {
+	RemoteJid   string `json:"remoteJid,omitempty"`
+	FromMe      bool   `json:"fromMe,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Participant string `json:"participant,omitempty"`
+}
+
+type WookEncCommentMessageRaw struct {
+	TargetMessageKey *WookTargetMessageKey `json:"targetMessageKey,omitempty"`
+	EncPayload       []byte                `json:"encPayload,omitempty"`
+	EncIv            []byte                `json:"encIv,omitempty"`
 }
 
 type WookAudioMessageRaw struct {

--- a/lib/whatsmiau/models.go
+++ b/lib/whatsmiau/models.go
@@ -177,17 +177,10 @@ type ReactionMessageRaw struct {
 	SenderTimestampMs string   `json:"senderTimestampMs,omitempty"`
 }
 
-type WookTargetMessageKey struct {
-	RemoteJid   string `json:"remoteJid,omitempty"`
-	FromMe      bool   `json:"fromMe,omitempty"`
-	Id          string `json:"id,omitempty"`
-	Participant string `json:"participant,omitempty"`
-}
-
 type WookEncCommentMessageRaw struct {
-	TargetMessageKey *WookTargetMessageKey `json:"targetMessageKey,omitempty"`
-	EncPayload       []byte                `json:"encPayload,omitempty"`
-	EncIv            []byte                `json:"encIv,omitempty"`
+	TargetMessageKey *WookKey `json:"targetMessageKey,omitempty"`
+	EncPayload       string   `json:"encPayload,omitempty"`
+	EncIv            string   `json:"encIv,omitempty"`
 }
 
 type WookAudioMessageRaw struct {


### PR DESCRIPTION
## Description
- Added `encCommentMessage` parsing in incoming messages to set `messageType` instead of falling back to `"unknown"`.                                      
- Exposed `targetMessageKey`, `encPayload`, and `encIv` fields in the webhook payload.                                                                     
- Added `addressingMode` field (`"jid"` / `"lid"`) to the message key for Evolution API compatibility.                                                     
- Added `WookEncCommentMessageRaw` and `WookTargetMessageKey` structs to models.    

## Risk Level

- [ ] No functional changes
- [ ] Low risk change
- [x] May impact existing functionality
- [ ] Breaking change

## Review Notes

- [x] New feature
- [ ] Bug fix
- [ ] Test changes
- [ ] Documentation / README
- [ ] Configuration changes
- [ ] Refactoring


## Checklist

- [x] Code follows project standards
- [ ] Documentation updated (if applicable)
- [x] Tests executed successfully
