### PR TITLE
feat: implement history sync with Evolution-compatible format

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -462,6 +462,10 @@ var (
 const historySyncTimeout = 60 * time.Second
 
 func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance, e *events.HistorySync, eventMap map[string]bool) {
+	if e == nil || e.Data == nil {
+		return
+	}
+
 	progress := e.Data.GetProgress()
 	isLatest := progress >= 100
 

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -535,11 +535,18 @@ func cleanHistorySyncState(id string) {
 }
 
 func (s *Whatsmiau) resetHistorySyncWatchdog(id string) {
-	watchdog, loaded := historySyncWatchdog.LoadOrStore(id, time.AfterFunc(historySyncTimeout, func() {
+	if existing, ok := historySyncWatchdog.Load(id); ok {
+		existing.(*time.Timer).Reset(historySyncTimeout)
+		return
+	}
+
+	newTimer := time.AfterFunc(historySyncTimeout, func() {
 		cleanHistorySyncState(id)
-	}))
+	})
+	actual, loaded := historySyncWatchdog.LoadOrStore(id, newTimer)
 	if loaded {
-		watchdog.(*time.Timer).Reset(historySyncTimeout)
+		newTimer.Stop()
+		actual.(*time.Timer).Reset(historySyncTimeout)
 	}
 }
 

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -243,8 +243,10 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 				s.handleConnectionUpdateEvent(id, instance, "open", 200, eventMap)
 			case *events.Disconnected:
 				s.handleConnectionUpdateEvent(id, instance, "close", 0, eventMap)
+				s.stopHistorySyncWatchdog(id)
 			case *events.ConnectFailure:
 				s.handleConnectionUpdateEvent(id, instance, "close", int(e.Reason), eventMap)
+				s.stopHistorySyncWatchdog(id)
 			default:
 				zap.L().Debug("unknown event", zap.String("type", fmt.Sprintf("%T", evt)), zap.Any("raw", evt))
 			}
@@ -452,7 +454,61 @@ func (s *Whatsmiau) handlePictureEvent(id string, instance *models.Instance, e *
 	s.emit(wookData, instance.Webhook.Url)
 }
 
+var (
+	historySyncStarted  sync.Map
+	historySyncWatchdog sync.Map
+	historySyncProgress sync.Map
+)
+
+const historySyncTimeout = 60 * time.Second
+
 func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance, e *events.HistorySync, eventMap map[string]bool) {
+	progress := e.Data.GetProgress()
+	isLatest := progress >= 100
+
+	if instance.SyncFullHistory && eventMap["MESSAGES_UPSERT"] {
+		_, alreadyStarted := historySyncStarted.LoadOrStore(id, true)
+		if !alreadyStarted {
+		}
+
+		var messages []WookMessageData
+		for _, conv := range e.Data.Conversations {
+			for _, msg := range conv.GetMessages() {
+				if msg.Message == nil || msg.Message.Message == nil {
+					continue
+				}
+
+				messageData := s.buildMessageDataFromHistory(msg.Message, conv.GetName(), conv.GetDisplayName())
+				if messageData == nil {
+					continue
+				}
+
+				messageData.InstanceId = instance.ID
+				messages = append(messages, *messageData)
+			}
+		}
+
+		if len(messages) > 0 {
+			prog := int(progress)
+			wookEvent := &WookEvent[[]WookMessageData]{
+				Instance: instance.ID,
+				Data:     &messages,
+				DateTime: time.Now(),
+				Event:    WookMessagesSet,
+				IsLatest: &isLatest,
+				Progress: &prog,
+			}
+			s.emit(wookEvent, instance.Webhook.Url)
+		}
+
+		if isLatest {
+			s.stopHistorySyncWatchdog(id)
+		} else {
+			historySyncProgress.Store(id, progress)
+			s.resetHistorySyncWatchdog(id)
+		}
+	}
+
 	if !eventMap["CONTACTS_UPSERT"] {
 		return
 	}
@@ -470,6 +526,28 @@ func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance,
 	}
 
 	s.emit(wookData, instance.Webhook.Url)
+}
+
+func cleanHistorySyncState(id string) {
+	historySyncWatchdog.Delete(id)
+	historySyncStarted.Delete(id)
+	historySyncProgress.Delete(id)
+}
+
+func (s *Whatsmiau) resetHistorySyncWatchdog(id string) {
+	watchdog, loaded := historySyncWatchdog.LoadOrStore(id, time.AfterFunc(historySyncTimeout, func() {
+		cleanHistorySyncState(id)
+	}))
+	if loaded {
+		watchdog.(*time.Timer).Reset(historySyncTimeout)
+	}
+}
+
+func (s *Whatsmiau) stopHistorySyncWatchdog(id string) {
+	if watchdog, ok := historySyncWatchdog.Load(id); ok {
+		watchdog.(*time.Timer).Stop()
+	}
+	cleanHistorySyncState(id)
 }
 
 func (s *Whatsmiau) handleGroupInfoEvent(id string, instance *models.Instance, e *events.GroupInfo, eventMap map[string]bool) {
@@ -950,12 +1028,12 @@ func (s *Whatsmiau) convertEventMessage(id string, instance *models.Instance, ev
 		addressingMode = "jid"
 	}
 	key := &WookKey{
-		RemoteJid:       jid,
-		RemoteLid:       lid,
-		FromMe:          e.Info.IsFromMe,
-		Id:              e.Info.ID,
-		Participant:     senderJid,
-		AddressingMode:  addressingMode,
+		RemoteJid:      jid,
+		RemoteLid:      lid,
+		FromMe:         e.Info.IsFromMe,
+		Id:             e.Info.ID,
+		Participant:    senderJid,
+		AddressingMode: addressingMode,
 	}
 
 	// Determine status

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -455,7 +455,6 @@ func (s *Whatsmiau) handlePictureEvent(id string, instance *models.Instance, e *
 }
 
 var (
-	historySyncStarted  sync.Map
 	historySyncWatchdog sync.Map
 	historySyncProgress sync.Map
 )
@@ -467,10 +466,6 @@ func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance,
 	isLatest := progress >= 100
 
 	if instance.SyncFullHistory && eventMap["MESSAGES_UPSERT"] {
-		_, alreadyStarted := historySyncStarted.LoadOrStore(id, true)
-		if !alreadyStarted {
-		}
-
 		var messages []WookMessageData
 		for _, conv := range e.Data.Conversations {
 			for _, msg := range conv.GetMessages() {
@@ -530,7 +525,6 @@ func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance,
 
 func cleanHistorySyncState(id string) {
 	historySyncWatchdog.Delete(id)
-	historySyncStarted.Delete(id)
 	historySyncProgress.Delete(id)
 }
 

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -247,6 +247,8 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 			case *events.ConnectFailure:
 				s.handleConnectionUpdateEvent(id, instance, "close", int(e.Reason), eventMap)
 				s.stopHistorySyncWatchdog(id)
+			case *events.StreamReplaced:
+				s.stopHistorySyncWatchdog(id)
 			default:
 				zap.L().Debug("unknown event", zap.String("type", fmt.Sprintf("%T", evt)), zap.Any("raw", evt))
 			}
@@ -255,6 +257,8 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 }
 
 func (s *Whatsmiau) handleLoggedOut(id string) {
+	s.stopHistorySyncWatchdog(id)
+
 	client, ok := s.clients.Load(id)
 	if ok {
 		if err := s.deleteDeviceIfExists(context.Background(), client); err != nil {
@@ -459,7 +463,7 @@ var (
 	historySyncProgress sync.Map
 )
 
-const historySyncTimeout = 60 * time.Second
+const historySyncTimeout = 180 * time.Second
 
 func (s *Whatsmiau) handleHistorySyncEvent(id string, instance *models.Instance, e *events.HistorySync, eventMap map[string]bool) {
 	if e == nil || e.Data == nil {

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -547,11 +547,12 @@ func statusFromHistory(status waWeb.WebMessageInfo_Status, fromMe bool) string {
 // O padrão é pt-BR (base de usuários atual). Adicione novos idiomas estendendo o mapa.
 var fromMePushNames = map[string]string{
 	"pt-BR": "Você",
+	"en":    "You",
 }
 
 func fromMePushName(locale string) string {
 	if name, ok := fromMePushNames[locale]; ok {
 		return name
 	}
-	return fromMePushNames["pt-BR"]
+	return "You"
 }

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/verbeux-ai/whatsmiau/env"
 	"github.com/verbeux-ai/whatsmiau/models"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"go.uber.org/zap"
@@ -457,4 +458,100 @@ func buildBrazilianAlternate(number string) string {
 	default:
 		return ""
 	}
+}
+
+func (s *Whatsmiau) buildMessageDataFromHistory(msg *waWeb.WebMessageInfo, convName, displayName string) *WookMessageData {
+	if msg == nil || msg.Message == nil {
+		return nil
+	}
+
+	key := msg.GetKey()
+	if key == nil {
+		return nil
+	}
+
+	messageType, raw, ci := s.parseWAMessage(msg.Message)
+	if messageType == "" {
+		return nil
+	}
+
+	wookKey := &WookKey{
+		RemoteJid:      key.GetRemoteJID(),
+		FromMe:         key.GetFromMe(),
+		Id:             key.GetID(),
+		Participant:    key.GetParticipant(),
+		AddressingMode: "jid",
+	}
+
+	status := statusFromHistory(msg.GetStatus(), key.GetFromMe())
+
+	pushName := msg.GetPushName()
+	if key.GetFromMe() {
+		if pushName == "" {
+			pushName = fromMePushName("pt-BR")
+		}
+	} else if pushName == "" {
+
+		if jid := key.GetRemoteJID(); jid != "" {
+			if idx := strings.Index(jid, "@"); idx != -1 {
+				pushName = jid[:idx]
+			}
+		}
+		if pushName == "" {
+			switch {
+			case convName != "":
+				pushName = convName
+			case displayName != "":
+				pushName = displayName
+			}
+		}
+	}
+
+	var contextInfo *WookMessageContextInfo
+	if ci != nil {
+		contextInfo = &WookMessageContextInfo{
+			StanzaId:     ci.GetStanzaID(),
+			Participant:  ci.GetParticipant(),
+			Expiration:   int(ci.GetExpiration()),
+			MentionedJid: ci.GetMentionedJID(),
+		}
+		if qm := ci.GetQuotedMessage(); qm != nil {
+			_, qmRaw, _ := s.parseWAMessage(qm)
+			contextInfo.QuotedMessage = qmRaw
+		}
+	}
+
+	return &WookMessageData{
+		Key:              wookKey,
+		PushName:         pushName,
+		Status:           status,
+		Message:          raw,
+		MessageType:      messageType,
+		MessageTimestamp: int(msg.GetMessageTimestamp()),
+		Source:           "unknown",
+		ContextInfo:      contextInfo,
+	}
+}
+
+func statusFromHistory(status waWeb.WebMessageInfo_Status, fromMe bool) string {
+	if fromMe {
+		return "SENT"
+	}
+	if status == waWeb.WebMessageInfo_ERROR {
+		return "DELIVERY_ACK"
+	}
+	return waWeb.WebMessageInfo_Status_name[int32(status)]
+}
+
+// fromMePushNames mapeia locale → push name para mensagens enviadas pelo usuário.
+// O padrão é pt-BR (base de usuários atual). Adicione novos idiomas estendendo o mapa.
+var fromMePushNames = map[string]string{
+	"pt-BR": "Você",
+}
+
+func fromMePushName(locale string) string {
+	if name, ok := fromMePushNames[locale]; ok {
+		return name
+	}
+	return fromMePushNames["pt-BR"]
 }

--- a/lib/whatsmiau/models.go
+++ b/lib/whatsmiau/models.go
@@ -10,6 +10,7 @@ type Wook string
 
 const (
 	WookMessagesUpsert   Wook = "messages.upsert"
+	WookMessagesSet      Wook = "messages.set"
 	WookMessagesUpdate   Wook = "messages.update"
 	WookContactsUpsert   Wook = "contacts.upsert"
 	WookConnectionUpdate Wook = "connection.update"
@@ -25,6 +26,8 @@ type WookEvent[data any] struct {
 	ServerUrl   string    `json:"server_url,omitempty"`
 	Apikey      string    `json:"apikey,omitempty"`
 	Event       Wook      `json:"event,omitempty"`
+	IsLatest    *bool     `json:"isLatest,omitempty"`
+	Progress    *int      `json:"progress,omitempty"`
 }
 
 type WookMessageData struct {

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -15,12 +15,14 @@ import (
 	"github.com/verbeux-ai/whatsmiau/repositories/instances"
 	"github.com/verbeux-ai/whatsmiau/services"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
 	waLog "go.mau.fi/whatsmeow/util/log"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
+	"google.golang.org/protobuf/proto"
 )
 
 type Whatsmiau struct {
@@ -257,6 +259,27 @@ func (s *Whatsmiau) ensurePairingCode(ctx context.Context, id string, client *wh
 	return code
 }
 
+var devicePropsMu sync.Mutex
+
+func applyDevicePropsForInstance(instance *models.Instance) {
+	if instance.SyncFullHistory {
+		store.DeviceProps.RequireFullSync = proto.Bool(true)
+		if store.DeviceProps.HistorySyncConfig == nil {
+			store.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{}
+		}
+		store.DeviceProps.HistorySyncConfig.FullSyncDaysLimit = proto.Uint32(3650)
+		store.DeviceProps.HistorySyncConfig.FullSyncSizeMbLimit = proto.Uint32(51200)
+		store.DeviceProps.HistorySyncConfig.StorageQuotaMb = proto.Uint32(51200)
+	} else {
+		store.DeviceProps.RequireFullSync = nil
+		if store.DeviceProps.HistorySyncConfig != nil {
+			store.DeviceProps.HistorySyncConfig.FullSyncDaysLimit = nil
+			store.DeviceProps.HistorySyncConfig.FullSyncSizeMbLimit = nil
+			store.DeviceProps.HistorySyncConfig.StorageQuotaMb = nil
+		}
+	}
+}
+
 func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.Client, error) {
 	lock, _ := s.lockConnection.LoadOrStore(id, &sync.Mutex{})
 	lock.Lock()
@@ -265,7 +288,14 @@ func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.C
 	client, ok := s.clients.Load(id)
 	if !ok {
 		device := s.container.NewDevice()
+
+		devicePropsMu.Lock()
+		if inst := s.getInstanceCached(id); inst != nil {
+			applyDevicePropsForInstance(inst)
+		}
 		client = whatsmeow.NewClient(device, s.logger)
+		devicePropsMu.Unlock()
+
 		s.clients.Store(id, client)
 	}
 
@@ -297,7 +327,15 @@ func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.C
 		}
 
 		device := s.container.NewDevice()
-		client = whatsmeow.NewClient(device, s.logger)
+
+		if inst := s.getInstanceCached(id); inst != nil {
+			devicePropsMu.Lock()
+			applyDevicePropsForInstance(inst)
+			client = whatsmeow.NewClient(device, s.logger)
+			devicePropsMu.Unlock()
+		} else {
+			client = whatsmeow.NewClient(device, s.logger)
+		}
 		s.clients.Store(id, client) // replaces old client
 	}
 

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -16,6 +16,7 @@ import (
 	"github.com/verbeux-ai/whatsmiau/services"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	"go.mau.fi/whatsmeow/proto/waWa6"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
@@ -261,22 +262,30 @@ func (s *Whatsmiau) ensurePairingCode(ctx context.Context, id string, client *wh
 
 var devicePropsMu sync.Mutex
 
-func applyDevicePropsForInstance(instance *models.Instance) {
-	if instance.SyncFullHistory {
-		store.DeviceProps.RequireFullSync = proto.Bool(true)
-		if store.DeviceProps.HistorySyncConfig == nil {
-			store.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{}
-		}
-		store.DeviceProps.HistorySyncConfig.FullSyncDaysLimit = proto.Uint32(3650)
-		store.DeviceProps.HistorySyncConfig.FullSyncSizeMbLimit = proto.Uint32(51200)
-		store.DeviceProps.HistorySyncConfig.StorageQuotaMb = proto.Uint32(51200)
-	} else {
-		store.DeviceProps.RequireFullSync = nil
-		if store.DeviceProps.HistorySyncConfig != nil {
-			store.DeviceProps.HistorySyncConfig.FullSyncDaysLimit = nil
-			store.DeviceProps.HistorySyncConfig.FullSyncSizeMbLimit = nil
-			store.DeviceProps.HistorySyncConfig.StorageQuotaMb = nil
-		}
+func setHistorySyncPayload(client *whatsmeow.Client) {
+	if client.Store == nil {
+		return
+	}
+
+	customProps := proto.Clone(store.DeviceProps).(*waCompanionReg.DeviceProps)
+	customProps.RequireFullSync = proto.Bool(true)
+	if customProps.HistorySyncConfig == nil {
+		customProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{}
+	}
+	customProps.HistorySyncConfig.FullSyncDaysLimit = proto.Uint32(3650)
+	customProps.HistorySyncConfig.FullSyncSizeMbLimit = proto.Uint32(51200)
+	customProps.HistorySyncConfig.StorageQuotaMb = proto.Uint32(51200)
+
+	client.GetClientPayload = func() *waWa6.ClientPayload {
+		devicePropsMu.Lock()
+		defer devicePropsMu.Unlock()
+
+		oldProps := store.DeviceProps
+		store.DeviceProps = customProps
+		payload := client.Store.GetClientPayload()
+		store.DeviceProps = oldProps
+
+		return payload
 	}
 }
 
@@ -289,12 +298,11 @@ func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.C
 	if !ok {
 		device := s.container.NewDevice()
 
-		devicePropsMu.Lock()
-		if inst := s.getInstanceCached(id); inst != nil {
-			applyDevicePropsForInstance(inst)
-		}
 		client = whatsmeow.NewClient(device, s.logger)
-		devicePropsMu.Unlock()
+
+		if inst := s.getInstanceCached(id); inst != nil && inst.SyncFullHistory {
+			setHistorySyncPayload(client)
+		}
 
 		s.clients.Store(id, client)
 	}
@@ -328,13 +336,10 @@ func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.C
 
 		device := s.container.NewDevice()
 
-		if inst := s.getInstanceCached(id); inst != nil {
-			devicePropsMu.Lock()
-			applyDevicePropsForInstance(inst)
-			client = whatsmeow.NewClient(device, s.logger)
-			devicePropsMu.Unlock()
-		} else {
-			client = whatsmeow.NewClient(device, s.logger)
+		client = whatsmeow.NewClient(device, s.logger)
+
+		if inst := s.getInstanceCached(id); inst != nil && inst.SyncFullHistory {
+			setHistorySyncPayload(client)
 		}
 		s.clients.Store(id, client) // replaces old client
 	}


### PR DESCRIPTION
## Description
                                                                                                                                 
Adiciona processamento completo de History Sync do WhatsApp com formato compatível com a Evolution API.                               
                                                                                                                                                           
#### Fluxo de arquitetura                                                                                                                                                                          
```
 1. POST /instance/create { syncFullHistory: true }                                                                                                         
 2. POST /instance/:id/connect                                                                                                                              
  │                                                                                                                                                          
  ▼                                                                                                                                                          
  generateClient()                                                                                                                                           
    ├── container.NewDevice()                                                                                                                              
    ├── whatsmeow.NewClient(device, log)                                                                                                                     
    ├── Se SyncFullHistory:                                                                                                                                  
    │     └── setHistorySyncPayload(client)                                                                                                                  
    │           ├── proto.Clone(store.DeviceProps) → cópia com RequireFullSync=true                                                                          
    │           └── client.GetClientPayload = func() {                                                                                                       
    │                 lock → troca global pela cópia → GetClientPayload() → restaura → unlock                                                                
    │               }                                                                                                                                        
    └── s.clients.Store(id, client)                                                                                                                          
  │                                                                                                                                                          
  ▼                                                                                                                                                          
  WhatsApp conecta → Connect() → handshake → GetClientPayload callback                                                                                       
  │                                    └── usa a CÓPIA do DeviceProps                                                                                        
  ▼                                                                                                                                                          
  WhatsApp envia chunks de HistorySync                                                                                                                       
  │                                                                                                                                                          
  ▼                                                                                                                                                          
  handleHistorySyncEvent()                                                                                                                                   
    ├── Detecta primeiro chunk via LoadOrStore                                                                                                               
    ├── Itera Conversations[].Messages[]                                                                                                                                                                                                       
    ├── Emite messages.set com data: [array], isLatest, progress                                                                                             
    └── Gerencia watchdog 60s para limpeza de estado interno                                                                                                 
  │                                                                                                                                                          
  ▼                                                                                                                                                          
  Em caso de Disconnect / ConnectFailure:                                                                                                                    
    └── stopHistorySyncWatchdog() → limpa maps
```                           
  - **DeviceProps por clone (sem race):** `store.DeviceProps` é global no whatsmeow e lido durante o handshake (`Connect()`). A solução cria um `proto.Clone` com `RequireFullSync=true` para cada instância e injeta via `client.GetClientPayload` callback. O mutex `devicePropsMu` protege a  troca temporária do ponteiro global dentro do callback. Cada instância tem sua própria cópia, sem race entre conexões concorrentes.                                                                                                   
  - **Webhook em lote:** mensagens são emitidas em array (não uma por uma). Cada chunk gera um único messages.set.                                                                                          
  - **Watchdog:** timer de 60s que só limpa estado interno (sync.Maps).
  - Cliente acompanha o progresso via isLatest + progress (mesma abordagem da Evolution).            

#### Contrato (messages.set)                                                                                                                         
                                                                                                                                                             
```
  {                                                                                                                                                          
    "event": "messages.set",                                                                                                                                 
    "instance": "instancia-123",                                                                                                                             
    "data": [                                                                                                                                                
      {                                 
        "key": {                                                                                                                                             
          "remoteJid": "275586*******88@lid",                                                                                                              
          "fromMe": false,                                                                                                                                   
          "id": "3BABBE6CE15FFBE91C66"                                                                                                                       
        },                              
        "pushName": "275586*******88",                                                                                                                       
        "status": "DELIVERY_ACK",                                                                                                                            
        "message": {                                                                                                                                         
          "conversation": "Olá"                                                                                                                              
        },                                                                                                                                                 
        "contextInfo": {                                                                                                                                     
          "stanzaId": "ABCD...",                                                                                                                             
          "participant": "5585*******@s.whatsapp.net",
          "mentionedJid": [],                                                                                                                                
          "quotedMessage": {                                                                                                                                 
            "conversation": "Mensagem citada"                                                                                                                
          }                                                                                                                                                  
        },                                                                                                                                                   
        "messageType": "conversation",                                                                                                                       
        "messageTimestamp": 1782399079,                                                                                                                      
        "instanceId": "instancia-123",
        "source": "unknown"                                                                                                                                  
      }                                                                                                                                                      
    ],                                                                                                                                                       
    "isLatest": true,                                                                                                                                       
    "progress": 100,                                                                                                                                                                                                                       
  }     
```            

## Risk Level

- [ ] No functional changes
- [ ] Low risk change
- [x] May impact existing functionality
- [ ] Breaking change

## Review Notes

- [x] New feature
- [ ] Bug fix
- [ ] Test changes
- [ ] Documentation / README
- [ ] Configuration changes
- [ ] Refactoring


## Checklist

- [x] Code follows project standards
- [ ] Documentation updated (if applicable)
- [x] Tests executed successfully
