### PR TITLE
Corrige webhook e proxy em instâncias do painel do manager

### DIFF
--- a/server/controllers/manager.go
+++ b/server/controllers/manager.go
@@ -21,12 +21,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var webhookEventOptions = map[whatsmiau.Wook]bool{
-	whatsmiau.WookMessagesUpsert:   true,
-	whatsmiau.WookMessagesUpdate:   true,
-	whatsmiau.WookContactsUpsert:   true,
-	whatsmiau.WookConnectionUpdate: true,
-	whatsmiau.WookMessagesDelete:   true,
+// Subscription names, not payload names: the emitter filters against these
+// screaming snake case keys, while the emitted payload carries the dotted
+// lowercase Wook* values.
+var webhookEventOptions = []string{
+	"MESSAGES_UPSERT",
+	"MESSAGES_UPDATE",
+	"MESSAGES_DELETE",
+	"MESSAGES_SET",
+	"CONTACTS_UPSERT",
+	"CONNECTION_UPDATE",
 }
 
 type ManagerTemplates struct {
@@ -42,9 +46,15 @@ var managerFuncMap = template.FuncMap{
 		}
 		return *b
 	},
-	"hasEvent": func(events []string, event whatsmiau.Wook) bool {
+	"derefEnabled": func(b *bool) bool {
+		if b == nil {
+			return true
+		}
+		return *b
+	},
+	"hasEvent": func(events []string, event string) bool {
 		for _, e := range events {
-			if whatsmiau.Wook(e) == event {
+			if e == event {
 				return true
 			}
 		}
@@ -395,15 +405,24 @@ func (s *Manager) UpdateInstance(ctx echo.Context) error {
 		return ctx.String(http.StatusOK, "")
 	}
 
+	webhookEnabled := req.WebhookEnabled != nil
 	webhookByEvents := req.WebhookByEvents != nil
 	webhookBase64 := req.WebhookBase64 != nil
 
+	// Unchecking every box sends no field at all, and the repository skips nil
+	// slices. An empty non-nil slice is what actually clears the selection.
+	events := req.WebhookEvents
+	if events == nil {
+		events = []string{}
+	}
+
 	toUpdate := &models.Instance{
 		Webhook: models.InstanceWebhook{
+			Enabled:  &webhookEnabled,
 			Url:      req.WebhookURL,
 			ByEvents: &webhookByEvents,
 			Base64:   &webhookBase64,
-			Events:   req.WebhookEvents,
+			Events:   events,
 		},
 		InstanceProxy: models.InstanceProxy{
 			ProxyHost:     req.ProxyHost,

--- a/server/controllers/manager.go
+++ b/server/controllers/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"html/template"
+	"math/rand/v2"
 	"net/http"
 
 	"github.com/go-playground/validator/v10"
@@ -199,7 +200,21 @@ func (s *Manager) CreateInstance(ctx echo.Context) error {
 		return s.renderGridWithError(ctx, "instance_name_required")
 	}
 
-	if err := s.repo.Create(c, &models.Instance{ID: req.InstanceName}); err != nil {
+	instance := &models.Instance{ID: req.InstanceName}
+
+	if len(env.Env.ProxyAddresses) > 0 {
+		rd := rand.IntN(len(env.Env.ProxyAddresses))
+		proxyUrl := env.Env.ProxyAddresses[rd]
+
+		proxy, err := parseProxyURL(proxyUrl)
+		if err != nil {
+			zap.L().Error("invalid proxy url on env", zap.String("proxy", proxyUrl), zap.Error(err))
+			return s.renderGridWithError(ctx, "instance_create_error")
+		}
+		instance.InstanceProxy = *proxy
+	}
+
+	if err := s.repo.Create(c, instance); err != nil {
 		if errors.Is(err, instances.ErrorAlreadyExists) {
 			return s.renderGridWithError(ctx, "instance_exists:"+req.InstanceName)
 		}

--- a/server/dto/manager.go
+++ b/server/dto/manager.go
@@ -16,6 +16,7 @@ type ManagerInstanceCard struct {
 
 type ManagerUpdateInstanceRequest struct {
 	WebhookURL      string   `form:"webhookUrl" validate:"omitempty,http_url"`
+	WebhookEnabled  *bool    `form:"webhookEnabled"`
 	WebhookBase64   *bool    `form:"webhookBase64"`
 	WebhookByEvents *bool    `form:"webhookByEvents"`
 	WebhookEvents   []string `form:"webhookEvents"`

--- a/server/templates/instance.html
+++ b/server/templates/instance.html
@@ -51,19 +51,23 @@
                 </div>
             </div>
             <div class="checkbox-group">
-                <input type="checkbox" id="webhookBase64" name="webhookBase64" value="true" {{if and .Instance.Webhook.Base64 (deref .Instance.Webhook.Base64)}}checked{{end}}>
+                <input type="checkbox" id="webhookEnabled" name="webhookEnabled" value="true" {{if derefEnabled .Instance.Webhook.Enabled}}checked{{end}}>
+                <label for="webhookEnabled">Webhook ativo</label>
+            </div>
+            <div class="checkbox-group">
+                <input type="checkbox" id="webhookBase64" name="webhookBase64" value="true" {{if deref .Instance.Webhook.Base64}}checked{{end}}>
                 <label for="webhookBase64">Base64</label>
             </div>
             <div class="checkbox-group" style="margin-bottom:.75rem;">
-                <input type="checkbox" id="webhookByEvents" name="webhookByEvents" value="true" {{if and .Instance.Webhook.ByEvents (deref .Instance.Webhook.ByEvents)}}checked{{end}}>
+                <input type="checkbox" id="webhookByEvents" name="webhookByEvents" value="true" {{if deref .Instance.Webhook.ByEvents}}checked{{end}}>
                 <label for="webhookByEvents">Filtrar por eventos</label>
             </div>
             <div class="flags-grid">
                 {{$events := .Instance.Webhook.Events}}
-                {{range $ev, $_ := .WebhookEventOptions}}
+                {{range $ev := .WebhookEventOptions}}
                 <div class="checkbox-group">
-                    <input type="checkbox" name="webhookEvents" value="{{$ev}}" {{if hasEvent $events $ev}}checked{{end}}>
-                    <label>{{$ev}}</label>
+                    <input type="checkbox" id="event-{{$ev}}" name="webhookEvents" value="{{$ev}}" {{if hasEvent $events $ev}}checked{{end}}>
+                    <label for="event-{{$ev}}">{{$ev}}</label>
                 </div>
                 {{end}}
             </div>


### PR DESCRIPTION
# Corrige webhook e proxy nas instâncias criadas pelo painel do manager

Esse PR resolve dois problemas do painel do manager. O primeiro é que as configurações de webhook salvas por lá simplesmente não funcionavam. O segundo é que toda instância criada pelo painel nascia sem proxy.

## O webhook do painel não funcionava

Na verdade eram três bugs juntos, todos no painel. O principal é que ele salvava os eventos com os nomes errados. O projeto tem duas convenções de nome pra eventos: os nomes de subscription, tipo `MESSAGES_UPSERT`, que é o que fica salvo em `Webhook.Events` e o que o filtro do emitter compara, e os nomes de payload, tipo `messages.upsert`, que é o que vai no campo `event` do webhook emitido (as constantes `whatsmiau.Wook*`). A lista de checkboxes foi montada com as constantes `Wook*`, ou seja, com nome de payload. Resultado: o painel gravava `"connection.update"` no Redis enquanto o emitter procura por `eventMap["CONNECTION_UPDATE"]` (dá pra ver em `lib/whatsmiau/event_emitter.go:613` e nos demais handlers). Nenhum evento marcado no painel passava no filtro, nunca. De quebra, o `MESSAGES_SET` nem aparecia na lista.

Além disso, o formulário não tinha campo pro `Webhook.Enabled`, então ele ficava `nil` pra sempre. E tinha um terceiro detalhe chato: desmarcar todos os eventos não limpava nada, porque checkbox desmarcado não é enviado pelo browser. Sem o campo `webhookEvents` na requisição, o DTO recebe `nil` e o repositório ignora slice nil (`repositories/instances/redis.go:93`). A lista antiga continuava salva e disparando, enquanto a tela, ao recarregar, mostrava tudo desmarcado.

A correção: a lista de eventos do painel agora usa os nomes de subscription corretos, com o `MESSAGES_SET` incluído. Entrou um checkbox novo de "Webhook ativo" que grava o `Enabled` explicitamente. Ele vem marcado por padrão quando o valor é `nil`, que é como o `Handle` já interpreta hoje, então uma instância que funciona não vai aparecer na tela como desativada. Ao salvar, o campo passa a ser gravado como `true` de fato, o que destrava o `connection.update`. E quando o usuário desmarca todos os eventos, o controller manda um slice vazio não-nil, que passa na checagem do repositório e limpa a seleção de verdade.

Sobre os nomes estarem hard-coded no painel: foi de propósito. A alternativa óbvia seria reusar as constantes `Wook*`, e é exatamente isso que causou o bug, porque elas nomeiam o payload emitido, não a subscription. As duas convenções cobrem o mesmo conjunto de eventos e se parecem demais, daí a confusão. Hoje não existe uma lista canônica pra reusar: os nomes de subscription estão espalhados como literais em 11 pontos do `event_emitter.go`, mais uma tabela no README. A API v1 também não valida nada, o `Webhook.Set` grava `request.Webhook.Events` direto no Redis, então até um `{"events": ["BLABLABLA"]}` é aceito em silêncio. O caminho certo é criar constantes compartilhadas no `lib/whatsmiau` e fazer o emitter consumi-las, mas isso mexe no núcleo do pipeline de eventos e merece um PR próprio. Esse aqui fica contido no painel, e a lista hard-coded carrega um comentário explicando a diferença entre as duas convenções pra ninguém tropeçar nisso de novo.

## Instância criada pelo painel vinha sem proxy

Instância criada pela API já ganhava um proxy sorteado de `PROXY_ADDRESSES` automaticamente. Pelo painel, não. O usuário tinha que abrir a tela de detalhes e preencher o proxy na mão, instância por instância.

A causa é que existem dois caminhos de criação independentes e a regra do proxy só existia em um deles. O `Instance.Create` da API (`server/controllers/instance.go:70-79`) sorteia um endereço quando o request não traz proxy explícito, enquanto o `Manager.CreateInstance` montava a `models.Instance` só com o `ID` e chamava o `s.repo.Create` direto, sem passar perto dessa lógica. No fundo, a regra de "instância nova herda proxy do env" morava dentro do handler da API, sem nenhum ponto compartilhado entre os dois controllers.

A correção traz o mesmo sorteio pra dentro do `Manager.CreateInstance` (`server/controllers/manager.go`), reaproveitando o `parseProxyURL` que a API já usa: sorteia um endereço de `env.Env.ProxyAddresses`, faz o parse e grava em `instance.InstanceProxy` antes do `repo.Create`. Sim, é lógica duplicada. Extrair um helper compartilhado pros dois controllers eliminaria essa classe de bug pra qualquer caller futuro, e é o que eu faria num PR que se propusesse a mexer nessa estrutura. Aqui preferi duplicar e manter o escopo pequeno, pelo mesmo motivo das constantes de evento.

## Testes

`go build ./...`, `go vet ./...` e `go test ./...` passam.