### PR TITLE
fix: enable group participant webhook events

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -629,7 +629,7 @@ func (s *Whatsmiau) emitGroupParticipantsUpdate(id string, instance *models.Inst
 }
 
 func (s *Whatsmiau) handleGroupParticipantsUpdateEvent(id string, instance *models.Instance, e *events.GroupInfo, eventMap map[string]bool) {
-	if !eventMap[string(WookGroupParticipantsUpdate)] {
+	if !eventMap["GROUP_PARTICIPANTS_UPDATE"] {
 		return
 	}
 
@@ -666,7 +666,7 @@ func (s *Whatsmiau) handleGroupParticipantsUpdateEvent(id string, instance *mode
 }
 
 func (s *Whatsmiau) handleJoinedGroupEvent(id string, instance *models.Instance, e *events.JoinedGroup, eventMap map[string]bool) {
-	if !eventMap[string(WookGroupParticipantsUpdate)] {
+	if !eventMap["GROUP_PARTICIPANTS_UPDATE"] {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- use the Manager-normalized GROUP_PARTICIPANTS_UPDATE event key in group participant handlers
- restore webhook delivery for add, remove, promote, demote, and joined-group events

## Testing
- Not run (per request)