### PR TITLE
feat: allow groupsIgnore to be updated dynamically via API

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -567,7 +567,7 @@ func (s *Whatsmiau) handleGroupInfoEvent(id string, instance *models.Instance, e
 		return
 	}
 
-	if instance.GroupsIgnore {
+	if instance.GroupsIgnore != nil && *instance.GroupsIgnore {
 		return
 	}
 
@@ -633,7 +633,7 @@ func (s *Whatsmiau) handleGroupParticipantsUpdateEvent(id string, instance *mode
 		return
 	}
 
-	if instance.GroupsIgnore {
+	if instance.GroupsIgnore != nil && *instance.GroupsIgnore {
 		return
 	}
 
@@ -670,7 +670,7 @@ func (s *Whatsmiau) handleJoinedGroupEvent(id string, instance *models.Instance,
 		return
 	}
 
-	if instance.GroupsIgnore {
+	if instance.GroupsIgnore != nil && *instance.GroupsIgnore {
 		return
 	}
 

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -318,7 +318,7 @@ func canIgnoreMessage(msg *events.Message) bool {
 
 // canIgnoreGroup returns true if group can be ignored
 func canIgnoreGroup(evt interface{}, instance *models.Instance) bool {
-	if !instance.GroupsIgnore {
+	if instance.GroupsIgnore == nil || !*instance.GroupsIgnore {
 		return false
 	}
 

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -632,6 +632,10 @@ func (s *Whatsmiau) Restart(ctx context.Context, id string) error {
 	return nil
 }
 
+func (s *Whatsmiau) InvalidateInstanceCache(id string) {
+	s.instanceCache.Delete(id)
+}
+
 func (s *Whatsmiau) GetJidLid(ctx context.Context, id string, jid types.JID) (string, string) {
 	newJid, newLid := s.extractJidLid(ctx, id, jid)
 	if strings.HasSuffix(newJid, "@lid") {

--- a/models/instance.go
+++ b/models/instance.go
@@ -4,7 +4,7 @@ type Instance struct {
 	ID                string          `json:"id,omitempty"`
 	RejectCall        bool            `json:"rejectCall,omitempty"`
 	MsgCall           string          `json:"msgCall,omitempty"`
-	GroupsIgnore      bool            `json:"groupsIgnore,omitempty"`
+	GroupsIgnore      *bool           `json:"groupsIgnore,omitempty"`
 	AlwaysOnline      bool            `json:"alwaysOnline,omitempty"`
 	ReadMessages      bool            `json:"readMessages,omitempty"`
 	ReadStatus        bool            `json:"readStatus,omitempty"`

--- a/repositories/instances/redis.go
+++ b/repositories/instances/redis.go
@@ -94,6 +94,10 @@ func (s *RedisInstance) Update(ctx context.Context, id string, toUpdate *models.
 		oldInstance.Webhook.Events = toUpdate.Webhook.Events
 	}
 
+	if toUpdate.GroupsIgnore != nil {
+		oldInstance.GroupsIgnore = toUpdate.GroupsIgnore
+	}
+
 	if toUpdate.ProxyHost != "" {
 		oldInstance.InstanceProxy = toUpdate.InstanceProxy
 	}

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -134,7 +134,8 @@ func (s *Instance) Update(ctx echo.Context) error {
 	}
 
 	c := ctx.Request().Context()
-	instance, err := s.repo.Update(c, request.ID, &models.Instance{
+
+	toUpdate := &models.Instance{
 		ID: request.ID,
 		Webhook: models.InstanceWebhook{
 			Enabled: request.Webhook.Enabled,
@@ -143,7 +144,12 @@ func (s *Instance) Update(ctx echo.Context) error {
 			Events:  request.Webhook.Events,
 		},
 		InstanceProxy: request.InstanceProxy,
-	})
+	}
+	if request.GroupsIgnore != nil {
+		toUpdate.GroupsIgnore = request.GroupsIgnore
+	}
+
+	instance, err := s.repo.Update(c, request.ID, toUpdate)
 	if err != nil {
 		if errors.Is(err, instances.ErrorNotFound) {
 			return utils.HTTPFail(ctx, http.StatusNotFound, err, "instance not found")
@@ -151,6 +157,9 @@ func (s *Instance) Update(ctx echo.Context) error {
 		zap.L().Error("failed to create instance", zap.Error(err))
 		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to update instance")
 	}
+
+	// Invalidate in-memory cache so settings like GroupsIgnore take effect immediately
+	s.whatsmiau.InvalidateInstanceCache(request.ID)
 
 	return ctx.JSON(http.StatusCreated, dto.UpdateInstanceResponse{
 		Instance: instance,

--- a/server/dto/instance.go
+++ b/server/dto/instance.go
@@ -41,8 +41,9 @@ type MigrationResult struct {
 }
 
 type UpdateInstanceRequest struct {
-	ID      string `json:"id,omitempty" param:"id" validate:"required" swaggerignore:"true"`
-	Webhook struct {
+	ID           string `json:"id,omitempty" param:"id" validate:"required" swaggerignore:"true"`
+	GroupsIgnore *bool  `json:"groupsIgnore,omitempty"`
+	Webhook      struct {
 		Enabled *bool    `json:"enabled,omitempty"`
 		Base64  bool     `json:"base64,omitempty"`
 		URL     string   `json:"url,omitempty"`


### PR DESCRIPTION
## Description
Allows `GroupsIgnore` to be updated dynamically via API, removing the need for reconnection or waiting for cache TTL.

## Risk Level

- [ ] No functional changes
- [x] Low risk change
- [ ] May impact existing functionality
- [ ] Breaking change

## Review Notes

- [x] New feature
- [ ] Bug fix
- [ ] Test changes
- [ ] Documentation / README
- [ ] Configuration changes
- [ ] Refactoring


## Checklist

- [x] Code follows project standards
- [ ] Documentation updated (if applicable)
- [x] Tests executed successfully                