### PR TITLE
fix: prevent deleted instances from being recreated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/beeper/argo-go v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
@@ -96,6 +97,7 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.27 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.mau.fi/libsignal v0.2.2 // indirect
 	go.mau.fi/util v0.9.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/beeper/argo-go v1.1.2 h1:UQI2G8F+NLfGTOmTUI0254pGKx/HUU/etbUGTJv91Fs=
@@ -233,6 +235,8 @@ github.com/verbeux-ai/whatsmeow v1.2.1-0.20260701003938-5cec36655f30 h1:KVPqLesl
 github.com/verbeux-ai/whatsmeow v1.2.1-0.20260701003938-5cec36655f30/go.mod h1:8ZUeuGDNw4GMtISbjWuK1A2Hs6ks2B3N34sronJClB8=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.mau.fi/libsignal v0.2.2 h1:QV+XdzQkm3x3aSG7FcqfGSZuFXz83pRZPBFaPygHbOU=

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -319,6 +319,14 @@ func (s *Whatsmiau) generateClient(ctx context.Context, id string) (*whatsmeow.C
 
 	client, ok := s.clients.Load(id)
 	if !ok {
+		instanceList, err := s.repo.List(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(instanceList) == 0 {
+			return nil, instances.ErrorNotFound
+		}
+
 		device := s.container.NewDevice()
 
 		client = whatsmeow.NewClient(device, s.logger)
@@ -568,6 +576,14 @@ func (s *Whatsmiau) Status(id string) (Status, error) {
 }
 
 func (s *Whatsmiau) Logout(ctx context.Context, id string) error {
+	lock, _ := s.lockConnection.LoadOrStore(id, &sync.Mutex{})
+	lock.Lock()
+	defer lock.Unlock()
+
+	return s.logoutUnlocked(ctx, id)
+}
+
+func (s *Whatsmiau) logoutUnlocked(ctx context.Context, id string) error {
 	client, ok := s.clients.Load(id)
 	if !ok {
 		zap.L().Warn("logout: client does not exist", zap.String("id", id))
@@ -575,7 +591,34 @@ func (s *Whatsmiau) Logout(ctx context.Context, id string) error {
 	}
 
 	s.deleteClient(id)
-	return s.deleteDeviceIfExists(ctx, client)
+	if err := s.deleteDeviceIfExists(ctx, client); err != nil {
+		return err
+	}
+	s.clearInstanceRuntimeState(id)
+	return nil
+}
+
+// Delete serializes runtime cleanup and Redis deletion with Connect/Restart.
+// Together with conditional Redis updates, this prevents late goroutines from
+// recreating an instance key after deletion.
+func (s *Whatsmiau) Delete(ctx context.Context, id string) error {
+	lock, _ := s.lockConnection.LoadOrStore(id, &sync.Mutex{})
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := s.logoutUnlocked(ctx, id); err != nil {
+		return err
+	}
+	s.clearInstanceRuntimeState(id)
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *Whatsmiau) clearInstanceRuntimeState(id string) {
+	s.qrCache.Delete(id)
+	s.pairingCache.Delete(id)
+	s.observerRunning.Delete(id)
+	s.instanceCache.Delete(id)
+	s.connectPhoneNumber.Delete(id)
 }
 
 func (s *Whatsmiau) Disconnect(id string) error {

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -584,6 +584,8 @@ func (s *Whatsmiau) Logout(ctx context.Context, id string) error {
 }
 
 func (s *Whatsmiau) logoutUnlocked(ctx context.Context, id string) error {
+	defer s.clearInstanceRuntimeState(id)
+
 	client, ok := s.clients.Load(id)
 	if !ok {
 		zap.L().Warn("logout: client does not exist", zap.String("id", id))
@@ -594,7 +596,6 @@ func (s *Whatsmiau) logoutUnlocked(ctx context.Context, id string) error {
 	if err := s.deleteDeviceIfExists(ctx, client); err != nil {
 		return err
 	}
-	s.clearInstanceRuntimeState(id)
 	return nil
 }
 
@@ -609,7 +610,6 @@ func (s *Whatsmiau) Delete(ctx context.Context, id string) error {
 	if err := s.logoutUnlocked(ctx, id); err != nil {
 		return err
 	}
-	s.clearInstanceRuntimeState(id)
 	return s.repo.Delete(ctx, id)
 }
 

--- a/lib/whatsmiau/whatsmeow_logout_test.go
+++ b/lib/whatsmiau/whatsmeow_logout_test.go
@@ -1,0 +1,48 @@
+package whatsmiau
+
+import (
+	"context"
+	"testing"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/verbeux-ai/whatsmiau/models"
+	"go.mau.fi/whatsmeow"
+)
+
+func TestLogoutUnlockedClearsRuntimeStateWithoutClient(t *testing.T) {
+	const id = "missing-client"
+	service := &Whatsmiau{
+		clients:            xsync.NewMap[string, *whatsmeow.Client](),
+		qrCache:            xsync.NewMap[string, string](),
+		pairingCache:       xsync.NewMap[string, string](),
+		observerRunning:    xsync.NewMap[string, *whatsmeow.Client](),
+		instanceCache:      xsync.NewMap[string, models.Instance](),
+		connectPhoneNumber: xsync.NewMap[string, string](),
+	}
+
+	service.qrCache.Store(id, "qr")
+	service.pairingCache.Store(id, "pairing")
+	service.observerRunning.Store(id, nil)
+	service.instanceCache.Store(id, models.Instance{ID: id})
+	service.connectPhoneNumber.Store(id, "5511999999999")
+
+	if err := service.logoutUnlocked(context.Background(), id); err != nil {
+		t.Fatalf("logoutUnlocked: %v", err)
+	}
+
+	if _, ok := service.qrCache.Load(id); ok {
+		t.Fatal("QR cache was not cleared")
+	}
+	if _, ok := service.pairingCache.Load(id); ok {
+		t.Fatal("pairing cache was not cleared")
+	}
+	if _, ok := service.observerRunning.Load(id); ok {
+		t.Fatal("observer marker was not cleared")
+	}
+	if _, ok := service.instanceCache.Load(id); ok {
+		t.Fatal("instance cache was not cleared")
+	}
+	if _, ok := service.connectPhoneNumber.Load(id); ok {
+		t.Fatal("connect phone number was not cleared")
+	}
+}

--- a/repositories/instances/redis.go
+++ b/repositories/instances/redis.go
@@ -36,20 +36,18 @@ func (s *RedisInstance) Create(ctx context.Context, instance *models.Instance) e
 		return ErrInstanceIDEmpty
 	}
 
-	result, err := s.List(ctx, instance.ID)
-	if err != nil {
-		return err
-	}
-
-	if len(result) > 0 {
-		return ErrorAlreadyExists
-	}
-
 	data, err := json.Marshal(instance)
 	if err != nil {
 		return err
 	}
-	return s.db.Set(ctx, s.key(instance.ID), data, redis.KeepTTL).Err()
+	created, err := s.db.SetNX(ctx, s.key(instance.ID), data, 0).Result()
+	if err != nil {
+		return err
+	}
+	if !created {
+		return ErrorAlreadyExists
+	}
+	return nil
 }
 
 func (s *RedisInstance) Update(ctx context.Context, id string, toUpdate *models.Instance) (*models.Instance, error) {
@@ -122,7 +120,17 @@ func (s *RedisInstance) Update(ctx context.Context, id string, toUpdate *models.
 		return nil, err
 	}
 
-	return &oldInstance, s.db.Set(ctx, s.key(id), data, redis.KeepTTL).Err()
+	err = s.db.SetArgs(ctx, s.key(id), data, redis.SetArgs{
+		Mode:    "XX",
+		KeepTTL: true,
+	}).Err()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrorNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &oldInstance, nil
 }
 
 func (s *RedisInstance) List(ctx context.Context, id string) ([]models.Instance, error) {
@@ -183,14 +191,12 @@ func (s *RedisInstance) Delete(ctx context.Context, id string) error {
 		return ErrInstanceIDEmpty
 	}
 
-	result, err := s.List(ctx, id)
+	deleted, err := s.db.Del(ctx, s.key(id)).Result()
 	if err != nil {
 		return err
 	}
-
-	if len(result) <= 0 {
+	if deleted == 0 {
 		return ErrorNotFound
 	}
-
-	return s.db.Del(ctx, s.key(id)).Err()
+	return nil
 }

--- a/repositories/instances/redis_test.go
+++ b/repositories/instances/redis_test.go
@@ -1,0 +1,82 @@
+package instances
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/verbeux-ai/whatsmiau/models"
+)
+
+func newTestRepository(t *testing.T) (*RedisInstance, *redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewRedis(client), client, server
+}
+
+func TestCreateIsAtomic(t *testing.T) {
+	repo, _, _ := newTestRepository(t)
+	ctx := context.Background()
+
+	if err := repo.Create(ctx, &models.Instance{ID: "same"}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if err := repo.Create(ctx, &models.Instance{ID: "same"}); !errors.Is(err, ErrorAlreadyExists) {
+		t.Fatalf("second create error = %v, want ErrorAlreadyExists", err)
+	}
+}
+
+type deleteBeforeConditionalSetHook struct {
+	server *miniredis.Miniredis
+	key    string
+}
+
+func (h deleteBeforeConditionalSetHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if cmd.Name() == "set" && strings.EqualFold(cmd.Args()[len(cmd.Args())-1].(string), "XX") {
+		h.server.Del(h.key)
+	}
+	return ctx, nil
+}
+
+func (deleteBeforeConditionalSetHook) AfterProcess(context.Context, redis.Cmder) error {
+	return nil
+}
+
+func (deleteBeforeConditionalSetHook) BeforeProcessPipeline(ctx context.Context, _ []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+
+func (deleteBeforeConditionalSetHook) AfterProcessPipeline(context.Context, []redis.Cmder) error {
+	return nil
+}
+
+func TestUpdateDoesNotResurrectDeletedKey(t *testing.T) {
+	repo, client, server := newTestRepository(t)
+	ctx := context.Background()
+	instance := &models.Instance{ID: "race"}
+
+	if err := repo.Create(ctx, instance); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	client.AddHook(deleteBeforeConditionalSetHook{server: server, key: repo.key(instance.ID)})
+
+	_, err := repo.Update(ctx, instance.ID, &models.Instance{RemoteJID: "123@s.whatsapp.net"})
+	if !errors.Is(err, ErrorNotFound) {
+		t.Fatalf("update error = %v, want ErrorNotFound", err)
+	}
+	if server.Exists(repo.key(instance.ID)) {
+		t.Fatal("conditional update resurrected the deleted Redis key")
+	}
+}
+
+func TestDeleteReportsMissingInstance(t *testing.T) {
+	repo, _, _ := newTestRepository(t)
+	if err := repo.Delete(context.Background(), "missing"); !errors.Is(err, ErrorNotFound) {
+		t.Fatalf("delete error = %v, want ErrorNotFound", err)
+	}
+}

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -423,24 +423,12 @@ func (s *Instance) Delete(ctx echo.Context) error {
 		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
 	}
 
-	result, err := s.repo.List(c, request.ID)
-	if err != nil {
-		zap.L().Error("failed to list instances", zap.Error(err))
-		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to list instances")
-	}
-
-	if len(result) == 0 {
-		return ctx.JSON(http.StatusOK, dto.DeleteInstanceResponse{
-			Message: "instance doesn't exists",
-		})
-	}
-
-	if err := s.whatsmiau.Logout(ctx.Request().Context(), request.ID); err != nil {
-		zap.L().Error("failed to disconnect instance", zap.Error(err))
-		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to logout instance")
-	}
-
-	if err := s.repo.Delete(c, request.ID); err != nil {
+	if err := s.whatsmiau.Delete(c, request.ID); err != nil {
+		if errors.Is(err, instances.ErrorNotFound) {
+			return ctx.JSON(http.StatusOK, dto.DeleteInstanceResponse{
+				Message: "instance doesn't exist",
+			})
+		}
 		zap.L().Error("failed to delete instance", zap.Error(err))
 		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to delete instance")
 	}


### PR DESCRIPTION
## Summary

- create Redis instance keys atomically with `SET NX`
- update existing keys with `SET XX KEEPTTL` so late events cannot resurrect deleted instances
- delete keys directly and idempotently
- serialize runtime cleanup and Redis deletion with connection operations
- verify the instance still exists before generating a new client
- add regression tests for duplicate creation and delete/update races

## Validation

- `go test ./...`
- `go test -race ./repositories/instances ./server/controllers ./lib/whatsmiau`
- `go vet ./...`

## Rollout

This is the first PR in the deletion-consistency rollout.