### PR TITLE
feat: allow disabling media storage per instance

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -1433,7 +1433,7 @@ func (s *Whatsmiau) uploadMessageFile(ctx context.Context, instance *models.Inst
 			b64Result = base64.StdEncoding.EncodeToString(data)
 		}
 	}
-	if s.fileStorage != nil {
+	if s.fileStorage != nil && shouldSaveMedia(instance) {
 		if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
 			zap.L().Error("failed to seek image", zap.Error(err))
 		}

--- a/lib/whatsmiau/helper.go
+++ b/lib/whatsmiau/helper.go
@@ -325,6 +325,13 @@ func canIgnoreMessage(msg *events.Message) bool {
 	return strings.Contains(msg.Info.Chat.String(), "status")
 }
 
+// shouldSaveMedia returns true if message media must be persisted in the file storage.
+// A nil SaveMedia means enabled, preserving the behavior of instances created before
+// this flag existed.
+func shouldSaveMedia(instance *models.Instance) bool {
+	return instance.SaveMedia == nil || *instance.SaveMedia
+}
+
 // canIgnoreGroup returns true if group can be ignored
 func canIgnoreGroup(evt interface{}, instance *models.Instance) bool {
 	if instance.GroupsIgnore == nil || !*instance.GroupsIgnore {

--- a/lib/whatsmiau/helper_test.go
+++ b/lib/whatsmiau/helper_test.go
@@ -1,0 +1,27 @@
+package whatsmiau
+
+import (
+	"testing"
+
+	"github.com/verbeux-ai/whatsmiau/models"
+)
+
+func TestShouldSaveMediaDefaultsToEnabledWhenUnset(t *testing.T) {
+	instance := &models.Instance{}
+
+	if !shouldSaveMedia(instance) {
+		t.Error("shouldSaveMedia(nil SaveMedia) = false, want true: instances created before the flag existed must keep persisting media")
+	}
+}
+
+func TestShouldSaveMediaRespectsExplicitValues(t *testing.T) {
+	enabled, disabled := true, false
+
+	if !shouldSaveMedia(&models.Instance{SaveMedia: &enabled}) {
+		t.Error("shouldSaveMedia(SaveMedia=true) = false, want true")
+	}
+
+	if shouldSaveMedia(&models.Instance{SaveMedia: &disabled}) {
+		t.Error("shouldSaveMedia(SaveMedia=false) = true, want false")
+	}
+}

--- a/models/instance.go
+++ b/models/instance.go
@@ -10,6 +10,7 @@ type Instance struct {
 	ReadStatus        bool            `json:"readStatus,omitempty"`
 	SyncFullHistory   bool            `json:"syncFullHistory,omitempty"`
 	SyncRecentHistory bool            `json:"syncRecentHistory,omitempty"`
+	SaveMedia         *bool           `json:"saveMedia,omitempty"`
 	RemoteJID         string          `json:"remoteJID,omitempty"`
 	Webhook           InstanceWebhook `json:"webhook,omitempty"`
 	InstanceProxy

--- a/repositories/instances/redis.go
+++ b/repositories/instances/redis.go
@@ -96,6 +96,10 @@ func (s *RedisInstance) Update(ctx context.Context, id string, toUpdate *models.
 		oldInstance.GroupsIgnore = toUpdate.GroupsIgnore
 	}
 
+	if toUpdate.SaveMedia != nil {
+		oldInstance.SaveMedia = toUpdate.SaveMedia
+	}
+
 	if toUpdate.ProxyHost != "" {
 		oldInstance.InstanceProxy = toUpdate.InstanceProxy
 	}

--- a/repositories/instances/redis_test.go
+++ b/repositories/instances/redis_test.go
@@ -80,3 +80,48 @@ func TestDeleteReportsMissingInstance(t *testing.T) {
 		t.Fatalf("delete error = %v, want ErrorNotFound", err)
 	}
 }
+
+// TestUpdateOnlyTouchesSaveMediaWhenProvided guards the pointer semantics of SaveMedia.
+// The value under test is true on purpose: with false, an update that wrongly forced the
+// field would also produce false and the test would pass without detecting anything.
+func TestUpdateOnlyTouchesSaveMediaWhenProvided(t *testing.T) {
+	repo, _, _ := newTestRepository(t)
+	ctx := context.Background()
+
+	enabled, disabled := true, false
+	if err := repo.Create(ctx, &models.Instance{ID: "media", SaveMedia: &enabled}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// An update that does not mention SaveMedia must leave it alone.
+	updated, err := repo.Update(ctx, "media", &models.Instance{RemoteJID: "123@s.whatsapp.net"})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.SaveMedia == nil {
+		t.Fatal("update without SaveMedia cleared the stored value")
+	}
+	if !*updated.SaveMedia {
+		t.Error("update without SaveMedia overwrote the stored value")
+	}
+
+	// An explicit false must be persisted, and must survive serialization: with a plain
+	// bool on the model, omitempty would drop it and it would read back as absent.
+	if _, err := repo.Update(ctx, "media", &models.Instance{SaveMedia: &disabled}); err != nil {
+		t.Fatalf("update to false: %v", err)
+	}
+
+	stored, err := repo.List(ctx, "media")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("len(list) = %d, want 1", len(stored))
+	}
+	if stored[0].SaveMedia == nil {
+		t.Fatal("explicit false vanished when serializing to Redis")
+	}
+	if *stored[0].SaveMedia {
+		t.Error("explicit false was not persisted")
+	}
+}

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -148,6 +148,9 @@ func (s *Instance) Update(ctx echo.Context) error {
 	if request.GroupsIgnore != nil {
 		toUpdate.GroupsIgnore = request.GroupsIgnore
 	}
+	if request.SaveMedia != nil {
+		toUpdate.SaveMedia = request.SaveMedia
+	}
 
 	instance, err := s.repo.Update(c, request.ID, toUpdate)
 	if err != nil {

--- a/server/dto/instance.go
+++ b/server/dto/instance.go
@@ -43,6 +43,7 @@ type MigrationResult struct {
 type UpdateInstanceRequest struct {
 	ID           string `json:"id,omitempty" param:"id" validate:"required" swaggerignore:"true"`
 	GroupsIgnore *bool  `json:"groupsIgnore,omitempty"`
+	SaveMedia    *bool  `json:"saveMedia,omitempty"`
 	Webhook      struct {
 		Enabled *bool    `json:"enabled,omitempty"`
 		Base64  bool     `json:"base64,omitempty"`

--- a/tests/integration/instance_test.go
+++ b/tests/integration/instance_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type instanceListItem struct {
+	ID        string `json:"id"`
+	SaveMedia *bool  `json:"saveMedia"`
+}
+
+func updateInstanceURL(t *testing.T) string {
+	return fmt.Sprintf("/v1/instance/update/%s", instanceID(t))
+}
+
+// fetchSaveMedia lê o valor persistido de saveMedia da instância de teste.
+func fetchSaveMedia(t *testing.T) *bool {
+	t.Helper()
+
+	resp := do(t, http.MethodGet, fmt.Sprintf("/v1/instance?id=%s", instanceID(t)), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var list []instanceListItem
+	mustDecode(t, resp, &list)
+	require.Len(t, list, 1, "instância de teste não encontrada")
+
+	return list[0].SaveMedia
+}
+
+func setSaveMedia(t *testing.T, value bool) {
+	t.Helper()
+
+	resp := do(t, http.MethodPut, updateInstanceURL(t), map[string]any{"saveMedia": value})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	drainClose(resp)
+}
+
+// TestSaveMediaSurvivesUnrelatedUpdate cobre o modo de falha do ponteiro: se
+// UpdateInstanceRequest.SaveMedia fosse declarado bool em vez de *bool, qualquer update
+// que omitisse o campo gravaria false e desligaria a persistência sem ninguém pedir.
+func TestSaveMediaSurvivesUnrelatedUpdate(t *testing.T) {
+	original := fetchSaveMedia(t)
+	t.Cleanup(func() {
+		// Se o campo estava ausente (nil), não há como restaurar a ausência pela API —
+		// omitir significa "não altere". Restaura para true, que é o comportamento
+		// equivalente a nil.
+		restore := true
+		if original != nil {
+			restore = *original
+		}
+		setSaveMedia(t, restore)
+	})
+
+	// O valor sob teste tem que ser true: se fosse false, um DTO declarado bool (o bug)
+	// também gravaria false no update seguinte e o teste passaria sem detectar nada.
+	setSaveMedia(t, true)
+	got := fetchSaveMedia(t)
+	require.NotNil(t, got, "saveMedia deveria estar persistido após update explícito")
+	require.True(t, *got)
+
+	// Update de um campo não relacionado, sem mencionar saveMedia. Usa groupsIgnore de
+	// propósito, e não um campo de webhook, para não acionar de raspão o reset de
+	// webhook.base64 e transformar isso num falso negativo.
+	resp := do(t, http.MethodPut, updateInstanceURL(t), map[string]any{"groupsIgnore": false})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	drainClose(resp)
+
+	got = fetchSaveMedia(t)
+	require.NotNil(t, got, "update não relacionado apagou saveMedia")
+	require.True(t, *got, "update não relacionado sobrescreveu saveMedia: o DTO precisa ser *bool")
+
+	// Um false explícito precisa sobreviver à serialização para o Redis. Com bool em vez
+	// de *bool no model, omitempty descartaria o campo e ele voltaria como ausente.
+	setSaveMedia(t, false)
+	got = fetchSaveMedia(t)
+	require.NotNil(t, got, "false explícito desapareceu na serialização")
+	require.False(t, *got)
+}


### PR DESCRIPTION
## Motivação

O upload de mídia para o GCS é decidido uma única vez no boot, por `GCS_ENABLED`, e o ponto de decisão só verifica se o storage existe:

```go
if s.fileStorage != nil {   // event_emitter.go
```

Nenhuma propriedade da instância participa. Consequência: com `GCS_ENABLED=true`, toda instância com webhook habilitado persiste sua mídia no mesmo bucket, e não há forma de uma instância optar por não persistir.

O `webhook.base64` não resolve, porque é aditivo e não alternativo — os dois blocos são `if`s independentes, então `base64: true` grava no bucket **e** manda inline.

## O que muda

Um campo `saveMedia` no model da instância, lido no único ponto de decisão do upload:

```go
if s.fileStorage != nil && shouldSaveMedia(instance) {
```

`uploadMessageFile` já recebia `instance`, então nenhuma assinatura de função muda.

Propagação seguindo o padrão já existente do `groupsIgnore`: campo ponteiro no model, propagação condicional no controller e no `repo.Update`, e `InvalidateInstanceCache` (já chamado no `Update`) fazendo a config valer sem restart. `POST /instance` funciona de graça pelo embed de `*models.Instance` no `CreateInstanceRequest`.

## Retrocompatibilidade

`nil` significa gravar. Instâncias já persistidas no Redis não têm o campo, ficam `nil` e seguem gravando — o deploy não altera o comportamento de ninguém.

| Estado | Antes | Depois |
|---|---|---|
| Existente no Redis, sem o campo | grava | grava |
| Criada sem informar `saveMedia` | grava | grava |
| `saveMedia: true` | n/a | grava |
| `saveMedia: false` | n/a | não grava; `mediaUrl` ausente do payload |

Com `GCS_ENABLED=false` nada muda: a condição curto-circuita no primeiro termo.

Com `saveMedia: false`, o download da mídia e o arquivo temporário continuam acontecendo — são necessários para extrair extensão e gerar o base64. Apenas o upload é evitado.

## Por que ponteiro

`*bool` no model **e** no DTO de update, por dois motivos distintos:

1. Como `bool` no DTO, qualquer update que omitisse o campo enviaria `false` e desligaria a persistência silenciosamente. É o que acontece hoje com `webhook.base64`: o DTO é `bool` e o controller monta `Base64: &[]bool{request.Webhook.Base64}[0]`, um ponteiro sempre não-nil, então um `PUT` de proxy ou de URL zera o base64 da instância. Não corrigi isso aqui para não misturar escopos, mas vale como follow-up.
2. Como `bool` no model, `omitempty` descartaria um `false` explícito na serialização para o Redis, e ele voltaria como ausente — isto é, "grava".

## Testes

- `repositories/instances/redis_test.go` — semântica do merge no `Update`, usando o harness `miniredis`: campo omitido não sobrescreve, `false` explícito persiste e sobrevive à serialização.
- `lib/whatsmiau/helper_test.go` — resolução `nil`/`true`/`false` do `shouldSaveMedia`.
- `tests/integration/instance_test.go` (tag `integration`) — round-trip via HTTP, incluindo um update de campo não relacionado para garantir que `saveMedia` não é resetado.

Os dois testes que cobrem o modo de falha do ponteiro foram rodados contra implementações deliberadamente quebradas para confirmar que falham. O valor sob teste é `true`, e não `false`, de propósito: com `false`, um bug de força-`false` produziria o valor esperado e o teste passaria sem detectar nada.

`go build`, `go vet` (incluindo `-tags integration`) e `go test ./...` limpos. O teste de integração foi executado contra um Redis real.

## Escopo

Deliberadamente fora:

- **Foto de perfil.** `uploadPic` permanece intocado; a flag afeta apenas mídia de mensagem.
- **Granularidade por tipo de mídia.** Um booleano por instância cobre o caso; roteamento por tipo multiplicaria config e teste sem demanda.
- **Bucket por instância.** O storage segue singleton com bucket único de `GCS_BUCKET`.
- **Validação cruzada com `webhook.base64`.** `saveMedia: false` com `base64: false` é aceito em silêncio: a mídia não vai a lugar nenhum. É config legítima para quem só processa texto, e espelha o comportamento que já existe com `GCS_ENABLED=false`.

## Não coberto por teste automatizado

Que `saveMedia: false` de fato não cria objeto no bucket. Isso exige GCS habilitado com credencial e mídia real chegando pelo WhatsApp; o `if` em si não foi exercido em runtime. Verificação manual: enviar mídia para uma instância com a flag desligada e conferir que nenhum objeto novo aparece no bucket e que o payload chega sem `mediaUrl`.

## Swagger

Não regenerado. O `docs/` no repositório já estava defasado antes desta mudança, e regenerar traria ~270 linhas, das quais só ~15 são do `saveMedia`. Prefiro não misturar drift preexistente com a feature — feliz em fazer em PR separado, ou aqui se preferirem.