### PR TITLE
fix: preserve canonical LID when resolving recipients

### DIFF
--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -103,18 +103,28 @@ func (s *Whatsmiau) resolveJID(ctx context.Context, client *whatsmeow.Client, ji
 		return jid
 	}
 
+	resolved := resolveExistingJID(jid, resp)
+	if resolved != jid {
+		zap.L().Debug(
+			"resolveJID: contact JID resolved",
+			zap.Stringer("from", jid),
+			zap.Stringer("to", resolved),
+		)
+	}
+
+	return resolved
+}
+
+func resolveExistingJID(fallback types.JID, resp []types.IsOnWhatsAppResponse) types.JID {
 	for _, item := range resp {
-		if item.IsIn {
-			resolved := jid
-			resolved.User = item.JID.User
-			if resolved.User != jid.User {
-				zap.L().Debug("resolveJID: brazilian number resolved", zap.String("from", jid.User), zap.String("to", resolved.User))
-			}
-			return resolved
+		if item.IsIn && !item.JID.IsEmpty() {
+			// Since whatsmeow v1.3, the canonical JID may use @lid. Preserve
+			// the full JID: copying only User would reinterpret a LID as a PN.
+			return item.JID.ToNonAD()
 		}
 	}
 
-	return jid
+	return fallback
 }
 
 type DeleteMessageForEveryoneRequest struct {

--- a/lib/whatsmiau/chat_test.go
+++ b/lib/whatsmiau/chat_test.go
@@ -1,0 +1,72 @@
+package whatsmiau
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestResolveExistingJIDPreservesLIDServer(t *testing.T) {
+	fallback := types.NewJID("5511999999999", types.DefaultUserServer)
+	lid := types.NewJID("123456789012345", types.HiddenUserServer)
+
+	got := resolveExistingJID(fallback, []types.IsOnWhatsAppResponse{{
+		Query:       fallback.User,
+		JID:         lid,
+		PhoneNumber: fallback,
+		IsIn:        true,
+	}})
+
+	if got != lid {
+		t.Fatalf("resolveExistingJID() = %s, want %s", got, lid)
+	}
+}
+
+func TestResolveExistingJIDKeepsPhoneNumberServer(t *testing.T) {
+	fallback := types.NewJID("5511999999999", types.DefaultUserServer)
+	alternate := types.NewJID("551199999999", types.DefaultUserServer)
+
+	got := resolveExistingJID(fallback, []types.IsOnWhatsAppResponse{{
+		Query: alternate.User,
+		JID:   alternate,
+		IsIn:  true,
+	}})
+
+	if got != alternate {
+		t.Fatalf("resolveExistingJID() = %s, want %s", got, alternate)
+	}
+}
+
+func TestResolveExistingJIDRemovesDevicePart(t *testing.T) {
+	fallback := types.NewJID("5511999999999", types.DefaultUserServer)
+	deviceLID := types.NewADJID("123456789012345", types.LIDDomain, 2)
+	want := deviceLID.ToNonAD()
+
+	got := resolveExistingJID(fallback, []types.IsOnWhatsAppResponse{{
+		JID:  deviceLID,
+		IsIn: true,
+	}})
+
+	if got != want {
+		t.Fatalf("resolveExistingJID() = %s, want %s", got, want)
+	}
+}
+
+func TestResolveExistingJIDFallsBackWhenNoNumberExists(t *testing.T) {
+	fallback := types.NewJID("5511999999999", types.DefaultUserServer)
+
+	got := resolveExistingJID(fallback, []types.IsOnWhatsAppResponse{
+		{
+			JID:  types.NewJID("123456789012345", types.HiddenUserServer),
+			IsIn: false,
+		},
+		{
+			JID:  types.EmptyJID,
+			IsIn: true,
+		},
+	})
+
+	if got != fallback {
+		t.Fatalf("resolveExistingJID() = %s, want fallback %s", got, fallback)
+	}
+}


### PR DESCRIPTION
## Context

After upgrading the whatsmeow fork to v1.3.0, IsOnWhatsApp may return the canonical recipient as an @lid JID. resolveJID copied only the User portion onto the original @s.whatsapp.net JID, causing LID identifiers to be reinterpreted as phone numbers. SendMessage then failed with no LID found.

Production validation showed that all 18 unique failed targets sampled from the last 15 minutes already existed in whatsmeow_lid_map as LIDs.

## Fix

- Preserve the complete canonical JID returned by IsOnWhatsApp, including the @lid server.
- Normalize device JIDs with ToNonAD before sending.
- Keep the original JID as fallback when no valid registered recipient is returned.
- Add regression tests for LID, PN alternate, device JID, and fallback behavior.

## Validation

- go test -count=1 ./...
- go vet ./...
- go test -race -count=1 ./lib/whatsmiau

This covers text, audio, image, document, and the other message paths that share resolveJID.