### PR TITLE
feat: add paid MCP history retention

### DIFF
--- a/lib/whatsmiau/contact.go
+++ b/lib/whatsmiau/contact.go
@@ -1,0 +1,40 @@
+package whatsmiau
+
+import (
+	"context"
+	"sort"
+
+	"go.mau.fi/whatsmeow"
+)
+
+type ListContactsRequest struct{ InstanceID string }
+
+type ContactResponse struct {
+	JID           string `json:"jid"`
+	Found         bool   `json:"found"`
+	FirstName     string `json:"firstName,omitempty"`
+	FullName      string `json:"fullName,omitempty"`
+	PushName      string `json:"pushName,omitempty"`
+	BusinessName  string `json:"businessName,omitempty"`
+	RedactedPhone string `json:"redactedPhone,omitempty"`
+}
+
+// ListContacts returns the current Whatsmeow contact cache. It intentionally
+// excludes profile pictures and any media so the manager can bootstrap an MCP
+// dataset without moving binary or expiring URL data between services.
+func (s *Whatsmiau) ListContacts(ctx context.Context, req *ListContactsRequest) ([]ContactResponse, error) {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok || client.Store == nil || client.Store.Contacts == nil {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+	contacts, err := client.Store.Contacts.GetAllContacts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]ContactResponse, 0, len(contacts))
+	for jid, info := range contacts {
+		result = append(result, ContactResponse{JID: jid.ToNonAD().String(), Found: info.Found, FirstName: info.FirstName, FullName: info.FullName, PushName: info.PushName, BusinessName: info.BusinessName, RedactedPhone: info.RedactedPhone})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].JID < result[j].JID })
+	return result, nil
+}

--- a/server/controllers/contact.go
+++ b/server/controllers/contact.go
@@ -1,0 +1,30 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/server/dto"
+	"github.com/verbeux-ai/whatsmiau/utils"
+)
+
+type Contact struct{ whatsmiau *whatsmiau.Whatsmiau }
+
+func NewContacts(service *whatsmiau.Whatsmiau) *Contact { return &Contact{whatsmiau: service} }
+
+func (s *Contact) List(ctx echo.Context) error {
+	var request dto.ListContactsQuery
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request")
+	}
+	contacts, err := s.whatsmiau.ListContacts(ctx.Request().Context(), &whatsmiau.ListContactsRequest{InstanceID: request.InstanceID})
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusNotFound, err, "instance is not connected")
+	}
+	return ctx.JSON(http.StatusOK, contacts)
+}

--- a/server/dto/contact.go
+++ b/server/dto/contact.go
@@ -1,0 +1,5 @@
+package dto
+
+type ListContactsQuery struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+}

--- a/server/routes/contact.go
+++ b/server/routes/contact.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
+	"github.com/verbeux-ai/whatsmiau/server/controllers"
+)
+
+func Contact(group *echo.Group) {
+	controller := controllers.NewContacts(whatsmiau.Get())
+	group.GET("", controller.List)
+}
+
+func ContactEVO(group *echo.Group) {
+	controller := controllers.NewContacts(whatsmiau.Get())
+	group.GET("/:instance", controller.List)
+}

--- a/server/routes/main.go
+++ b/server/routes/main.go
@@ -19,9 +19,11 @@ func V1(group *echo.Group) {
 	Chat(group.Group("/instance/:instance/chat"))
 	Group(group.Group("/instance/:instance/group"))
 	Community(group.Group("/instance/:instance/community"))
+	Contact(group.Group("/instance/:instance/contact"))
 
 	ChatEVO(group.Group("/chat"))
 	MessageEVO(group.Group("/message"))
 	GroupEVO(group.Group("/group"))
 	Webhook(group.Group("/webhook"))
+	ContactEVO(group.Group("/contact/fetchAll"))
 }


### PR DESCRIPTION
Expose authenticated contact snapshots for MCP dataset bootstrap, including Evolution-compatible alias.\n\nValidated: go test ./... and go vet ./...