### PR TITLE
feat: support quoted replies across all send routes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -7339,6 +7339,9 @@ const docTemplate = `{
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -7472,6 +7475,9 @@ const docTemplate = `{
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -7527,6 +7533,9 @@ const docTemplate = `{
                 },
                 "remoteJID": {
                     "type": "string"
+                },
+                "saveMedia": {
+                    "type": "boolean"
                 },
                 "syncFullHistory": {
                     "type": "boolean"
@@ -7791,6 +7800,9 @@ const docTemplate = `{
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -7915,7 +7927,16 @@ const docTemplate = `{
         "dto.QuotedKey": {
             "type": "object",
             "properties": {
+                "fromMe": {
+                    "type": "boolean"
+                },
                 "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
                     "type": "string"
                 }
             }
@@ -9084,6 +9105,9 @@ const docTemplate = `{
                 "proxyUsername": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "webhook": {
                     "type": "object",
                     "properties": {
@@ -9147,6 +9171,9 @@ const docTemplate = `{
                 },
                 "remoteJID": {
                     "type": "string"
+                },
+                "saveMedia": {
+                    "type": "boolean"
                 },
                 "syncFullHistory": {
                     "type": "boolean"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -212,6 +212,9 @@
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -345,6 +348,9 @@
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -400,6 +406,9 @@
                 },
                 "remoteJID": {
                     "type": "string"
+                },
+                "saveMedia": {
+                    "type": "boolean"
                 },
                 "syncFullHistory": {
                     "type": "boolean"
@@ -664,6 +673,9 @@
                 "remoteJID": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "syncFullHistory": {
                     "type": "boolean"
                 },
@@ -788,7 +800,16 @@
         },
         "dto.QuotedKey": {
             "properties": {
+                "fromMe": {
+                    "type": "boolean"
+                },
                 "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
                     "type": "string"
                 }
             },
@@ -1957,6 +1978,9 @@
                 "proxyUsername": {
                     "type": "string"
                 },
+                "saveMedia": {
+                    "type": "boolean"
+                },
                 "webhook": {
                     "properties": {
                         "base64": {
@@ -2020,6 +2044,9 @@
                 },
                 "remoteJID": {
                     "type": "string"
+                },
+                "saveMedia": {
+                    "type": "boolean"
                 },
                 "syncFullHistory": {
                     "type": "boolean"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -143,6 +143,8 @@ definitions:
         type: boolean
       remoteJID:
         type: string
+      saveMedia:
+        type: boolean
       syncFullHistory:
         type: boolean
       syncRecentHistory:
@@ -233,6 +235,8 @@ definitions:
         type: boolean
       remoteJID:
         type: string
+      saveMedia:
+        type: boolean
       syncFullHistory:
         type: boolean
       syncRecentHistory:
@@ -270,6 +274,8 @@ definitions:
         type: boolean
       remoteJID:
         type: string
+      saveMedia:
+        type: boolean
       syncFullHistory:
         type: boolean
       syncRecentHistory:
@@ -449,6 +455,8 @@ definitions:
         type: boolean
       remoteJID:
         type: string
+      saveMedia:
+        type: boolean
       syncFullHistory:
         type: boolean
       syncRecentHistory:
@@ -529,7 +537,13 @@ definitions:
     type: object
   dto.QuotedKey:
     properties:
+      fromMe:
+        type: boolean
       id:
+        type: string
+      participant:
+        type: string
+      remoteJid:
         type: string
     type: object
   dto.QuotedMessage:
@@ -1319,6 +1333,8 @@ definitions:
         type: string
       proxyUsername:
         type: string
+      saveMedia:
+        type: boolean
       webhook:
         properties:
           base64:
@@ -1361,6 +1377,8 @@ definitions:
         type: boolean
       remoteJID:
         type: string
+      saveMedia:
+        type: boolean
       syncFullHistory:
         type: boolean
       syncRecentHistory:

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -41,32 +41,7 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
 	data.RemoteJID = &resolved
 
-	//rJid := data.RemoteJID.ToNonAD().String()
-	var extendedMessage *waE2E.ExtendedTextMessage
-	if len(data.QuoteMessage) > 0 && len(data.QuoteMessageID) > 0 {
-		extendedMessage = &waE2E.ExtendedTextMessage{
-			//ContextInfo: &waE2E.ContextInfo{ // TODO: implement quoted message
-			//	StanzaID:    &data.QuoteMessageID,
-			//	Participant: &rJid,
-			//	QuotedMessage: &waE2E.Message{
-			//		Conversation: &data.QuoteMessage,
-			//		ProtocolMessage: &waE2E.ProtocolMessage{
-			//			Key: &waCommon.MessageKey{
-			//				RemoteJID:   &rJid,
-			//				FromMe:      &[]bool{true}[0],
-			//				ID:          &data.QuoteMessageID,
-			//				Participant: nil,
-			//			},
-			//		},
-			//	},
-			//},
-		}
-	}
-
-	res, err := client.SendMessage(ctx, *data.RemoteJID, &waE2E.Message{
-		Conversation:        &data.Text,
-		ExtendedTextMessage: extendedMessage,
-	})
+	res, err := client.SendMessage(ctx, *data.RemoteJID, buildSendTextMessage(data))
 	if err != nil {
 		return nil, err
 	}
@@ -75,6 +50,33 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 		ID:        res.ID,
 		CreatedAt: res.Timestamp,
 	}, nil
+}
+
+func buildSendTextMessage(data *SendText) *waE2E.Message {
+	if len(data.QuoteMessageID) == 0 {
+		return &waE2E.Message{
+			Conversation: proto.String(data.Text),
+		}
+	}
+
+	contextInfo := &waE2E.ContextInfo{
+		StanzaID: proto.String(data.QuoteMessageID),
+	}
+	if data.Participant != nil {
+		contextInfo.Participant = proto.String(data.Participant.String())
+	}
+	if len(data.QuoteMessage) > 0 {
+		contextInfo.QuotedMessage = &waE2E.Message{
+			Conversation: proto.String(data.QuoteMessage),
+		}
+	}
+
+	return &waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text:        proto.String(data.Text),
+			ContextInfo: contextInfo,
+		},
+	}
 }
 
 type SendAudioRequest struct {

--- a/lib/whatsmiau/send.go
+++ b/lib/whatsmiau/send.go
@@ -14,13 +14,17 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type Quote struct {
+	MessageID   string
+	Message     string
+	Participant *types.JID
+}
+
 type SendText struct {
-	Text           string     `json:"text"`
-	InstanceID     string     `json:"instance_id"`
-	RemoteJID      *types.JID `json:"remote_jid"`
-	QuoteMessageID string     `json:"quote_message_id"`
-	QuoteMessage   string     `json:"quote_message"`
-	Participant    *types.JID `json:"participant"`
+	Text       string     `json:"text"`
+	InstanceID string     `json:"instance_id"`
+	RemoteJID  *types.JID `json:"remote_jid"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendTextResponse struct {
@@ -52,40 +56,45 @@ func (s *Whatsmiau) SendText(ctx context.Context, data *SendText) (*SendTextResp
 	}, nil
 }
 
-func buildSendTextMessage(data *SendText) *waE2E.Message {
-	if len(data.QuoteMessageID) == 0 {
-		return &waE2E.Message{
-			Conversation: proto.String(data.Text),
-		}
+func buildContextInfo(q *Quote) *waE2E.ContextInfo {
+	if q == nil || len(q.MessageID) == 0 {
+		return nil
 	}
 
-	contextInfo := &waE2E.ContextInfo{
-		StanzaID: proto.String(data.QuoteMessageID),
+	ci := &waE2E.ContextInfo{
+		StanzaID: proto.String(q.MessageID),
 	}
-	if data.Participant != nil {
-		contextInfo.Participant = proto.String(data.Participant.String())
+	if q.Participant != nil {
+		ci.Participant = proto.String(q.Participant.String())
 	}
-	if len(data.QuoteMessage) > 0 {
-		contextInfo.QuotedMessage = &waE2E.Message{
-			Conversation: proto.String(data.QuoteMessage),
+	if len(q.Message) > 0 {
+		ci.QuotedMessage = &waE2E.Message{
+			Conversation: proto.String(q.Message),
+		}
+	}
+	return ci
+}
+
+func buildSendTextMessage(data *SendText) *waE2E.Message {
+	if data.Quote == nil || len(data.Quote.MessageID) == 0 {
+		return &waE2E.Message{
+			Conversation: proto.String(data.Text),
 		}
 	}
 
 	return &waE2E.Message{
 		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
 			Text:        proto.String(data.Text),
-			ContextInfo: contextInfo,
+			ContextInfo: buildContextInfo(data.Quote),
 		},
 	}
 }
 
 type SendAudioRequest struct {
-	AudioURL       string     `json:"text"`
-	InstanceID     string     `json:"instance_id"`
-	RemoteJID      *types.JID `json:"remote_jid"`
-	QuoteMessageID string     `json:"quote_message_id"`
-	QuoteMessage   string     `json:"quote_message"`
-	Participant    *types.JID `json:"participant"`
+	AudioURL   string     `json:"text"`
+	InstanceID string     `json:"instance_id"`
+	RemoteJID  *types.JID `json:"remote_jid"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendAudioResponse struct {
@@ -129,6 +138,7 @@ func (s *Whatsmiau) SendAudio(ctx context.Context, data *SendAudioRequest) (*Sen
 		FileEncSHA256: uploaded.FileEncSHA256,
 		DirectPath:    proto.String(uploaded.DirectPath),
 		Waveform:      waveForm,
+		ContextInfo:   buildContextInfo(data.Quote),
 	}
 
 	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
@@ -154,6 +164,7 @@ type SendDocumentRequest struct {
 	FileName   string     `json:"file_name"`
 	RemoteJID  *types.JID `json:"remote_jid"`
 	Mimetype   string     `json:"mimetype"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendDocumentResponse struct {
@@ -191,6 +202,7 @@ func (s *Whatsmiau) SendDocument(ctx context.Context, data *SendDocumentRequest)
 		FileEncSHA256: uploaded.FileEncSHA256,
 		DirectPath:    proto.String(uploaded.DirectPath),
 		Caption:       proto.String(data.Caption),
+		ContextInfo:   buildContextInfo(data.Quote),
 	}
 
 	resolved := s.resolveJID(ctx, client, *data.RemoteJID)
@@ -215,6 +227,7 @@ type SendImageRequest struct {
 	Caption    string     `json:"caption"`
 	RemoteJID  *types.JID `json:"remote_jid"`
 	Mimetype   string     `json:"mimetype"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 type SendImageResponse struct {
 	ID        string    `json:"id"`
@@ -254,6 +267,7 @@ func (s *Whatsmiau) SendImage(ctx context.Context, data *SendImageRequest) (*Sen
 		MediaKey:      uploaded.MediaKey,
 		FileEncSHA256: uploaded.FileEncSHA256,
 		DirectPath:    proto.String(uploaded.DirectPath),
+		ContextInfo:   buildContextInfo(data.Quote),
 	}
 
 	resolved := s.resolveJID(ctx, client, *data.RemoteJID)

--- a/lib/whatsmiau/send_more.go
+++ b/lib/whatsmiau/send_more.go
@@ -21,6 +21,7 @@ type SendVideoRequest struct {
 	RemoteJID   *types.JID `json:"remote_jid"`
 	Mimetype    string     `json:"mimetype"`
 	GifPlayback bool       `json:"gif_playback"`
+	Quote       *Quote     `json:"quote,omitempty"`
 }
 
 type SendVideoResponse struct {
@@ -58,6 +59,7 @@ func (s *Whatsmiau) SendVideo(ctx context.Context, data *SendVideoRequest) (*Sen
 		MediaKey:      uploaded.MediaKey,
 		FileEncSHA256: uploaded.FileEncSHA256,
 		DirectPath:    proto.String(uploaded.DirectPath),
+		ContextInfo:   buildContextInfo(data.Quote),
 	}
 	if data.GifPlayback {
 		video.GifPlayback = proto.Bool(true)
@@ -77,6 +79,7 @@ type SendPtvRequest struct {
 	InstanceID string     `json:"instance_id"`
 	VideoURL   string     `json:"video_url"`
 	RemoteJID  *types.JID `json:"remote_jid"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendPtvResponse struct {
@@ -110,6 +113,7 @@ func (s *Whatsmiau) SendPtv(ctx context.Context, data *SendPtvRequest) (*SendPtv
 		FileEncSHA256:   uploaded.FileEncSHA256,
 		DirectPath:      proto.String(uploaded.DirectPath),
 		VideoSourceType: waE2E.VideoMessage_USER_VIDEO.Enum(),
+		ContextInfo:     buildContextInfo(data.Quote),
 	}
 
 	res, err := client.SendMessage(ctx, resolved, &waE2E.Message{PtvMessage: &video})
@@ -126,6 +130,7 @@ type SendStickerRequest struct {
 	InstanceID string     `json:"instance_id"`
 	StickerURL string     `json:"sticker_url"`
 	RemoteJID  *types.JID `json:"remote_jid"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendStickerResponse struct {
@@ -158,6 +163,7 @@ func (s *Whatsmiau) SendSticker(ctx context.Context, data *SendStickerRequest) (
 		MediaKey:      uploaded.MediaKey,
 		FileEncSHA256: uploaded.FileEncSHA256,
 		DirectPath:    proto.String(uploaded.DirectPath),
+		ContextInfo:   buildContextInfo(data.Quote),
 	}
 
 	res, err := client.SendMessage(ctx, resolved, &waE2E.Message{StickerMessage: &sticker})
@@ -177,6 +183,7 @@ type SendLocationRequest struct {
 	Longitude  float64    `json:"longitude"`
 	Name       string     `json:"name"`
 	Address    string     `json:"address"`
+	Quote      *Quote     `json:"quote,omitempty"`
 }
 
 type SendLocationResponse struct {
@@ -194,6 +201,7 @@ func (s *Whatsmiau) SendLocation(ctx context.Context, data *SendLocationRequest)
 	loc := &waE2E.LocationMessage{
 		DegreesLatitude:  proto.Float64(data.Latitude),
 		DegreesLongitude: proto.Float64(data.Longitude),
+		ContextInfo:      buildContextInfo(data.Quote),
 	}
 	if data.Name != "" {
 		loc.Name = proto.String(data.Name)
@@ -225,6 +233,7 @@ type SendContactRequest struct {
 	InstanceID string            `json:"instance_id"`
 	RemoteJID  *types.JID        `json:"remote_jid"`
 	Contacts   []SendContactItem `json:"contacts"`
+	Quote      *Quote            `json:"quote,omitempty"`
 }
 
 type SendContactResponse struct {
@@ -252,7 +261,9 @@ func (s *Whatsmiau) SendContact(ctx context.Context, data *SendContactRequest) (
 
 	var msg *waE2E.Message
 	if len(data.Contacts) == 1 {
-		msg = &waE2E.Message{ContactMessage: contactToProto(data.Contacts[0])}
+		contact := contactToProto(data.Contacts[0])
+		contact.ContextInfo = buildContextInfo(data.Quote)
+		msg = &waE2E.Message{ContactMessage: contact}
 	} else {
 		contacts := make([]*waE2E.ContactMessage, 0, len(data.Contacts))
 		for _, c := range data.Contacts {
@@ -262,6 +273,7 @@ func (s *Whatsmiau) SendContact(ctx context.Context, data *SendContactRequest) (
 			ContactsArrayMessage: &waE2E.ContactsArrayMessage{
 				DisplayName: proto.String(data.Contacts[0].FullName),
 				Contacts:    contacts,
+				ContextInfo: buildContextInfo(data.Quote),
 			},
 		}
 	}
@@ -282,6 +294,7 @@ type SendPollRequest struct {
 	Name            string     `json:"name"`
 	SelectableCount int        `json:"selectable_count"`
 	Values          []string   `json:"values"`
+	Quote           *Quote     `json:"quote,omitempty"`
 }
 
 type SendPollResponse struct {
@@ -301,6 +314,7 @@ func (s *Whatsmiau) SendPoll(ctx context.Context, data *SendPollRequest) (*SendP
 	data.RemoteJID = &resolved
 
 	pollMsg := client.BuildPollCreation(data.Name, data.Values, data.SelectableCount)
+	pollMsg.PollCreationMessage.ContextInfo = buildContextInfo(data.Quote)
 
 	res, err := client.SendMessage(ctx, resolved, pollMsg)
 	if err != nil {

--- a/lib/whatsmiau/send_test.go
+++ b/lib/whatsmiau/send_test.go
@@ -3,6 +3,7 @@ package whatsmiau
 import (
 	"testing"
 
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
 )
@@ -19,7 +20,7 @@ func TestBuildSendTextMessageWithoutQuote(t *testing.T) {
 }
 
 func TestBuildSendTextMessageQuoteIDOnly(t *testing.T) {
-	msg := buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})
+	msg := buildSendTextMessage(&SendText{Text: "reply", Quote: &Quote{MessageID: "ABC123"}})
 
 	ext := msg.ExtendedTextMessage
 	if ext == nil {
@@ -44,9 +45,8 @@ func TestBuildSendTextMessageQuoteIDOnly(t *testing.T) {
 
 func TestBuildSendTextMessageQuoteWithConversation(t *testing.T) {
 	msg := buildSendTextMessage(&SendText{
-		Text:           "reply",
-		QuoteMessageID: "ABC123",
-		QuoteMessage:   "original text",
+		Text:  "reply",
+		Quote: &Quote{MessageID: "ABC123", Message: "original text"},
 	})
 
 	if msg.ExtendedTextMessage == nil {
@@ -68,10 +68,8 @@ func TestBuildSendTextMessageQuoteWithParticipant(t *testing.T) {
 	}
 
 	msg := buildSendTextMessage(&SendText{
-		Text:           "reply",
-		QuoteMessageID: "ABC123",
-		QuoteMessage:   "original text",
-		Participant:    &participant,
+		Text:  "reply",
+		Quote: &Quote{MessageID: "ABC123", Message: "original text", Participant: &participant},
 	})
 
 	if msg.ExtendedTextMessage == nil {
@@ -91,7 +89,7 @@ func TestBuildSendTextMessageQuoteWithParticipant(t *testing.T) {
 
 func TestBuildSendTextMessageQuoteTextPreserved(t *testing.T) {
 	// The reply text must go into ExtendedTextMessage.Text, not Conversation.
-	msg := buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})
+	msg := buildSendTextMessage(&SendText{Text: "reply", Quote: &Quote{MessageID: "ABC123"}})
 
 	if msg.GetConversation() != "" {
 		t.Fatalf("expected no Conversation field, got %q", msg.GetConversation())
@@ -99,7 +97,76 @@ func TestBuildSendTextMessageQuoteTextPreserved(t *testing.T) {
 	if msg.ExtendedTextMessage.GetText() != "reply" {
 		t.Fatalf("expected text=%q, got %q", "reply", msg.ExtendedTextMessage.GetText())
 	}
-	if !proto.Equal(msg, buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})) {
+	if !proto.Equal(msg, buildSendTextMessage(&SendText{Text: "reply", Quote: &Quote{MessageID: "ABC123"}})) {
 		t.Fatal("expected deterministic message construction")
+	}
+}
+
+func TestBuildContextInfoNoQuote(t *testing.T) {
+	if ci := buildContextInfo(nil); ci != nil {
+		t.Fatalf("expected nil ContextInfo, got %v", ci)
+	}
+	if ci := buildContextInfo(&Quote{}); ci != nil {
+		t.Fatalf("expected nil ContextInfo for empty quote, got %v", ci)
+	}
+}
+
+func TestBuildContextInfoQuoteIDOnly(t *testing.T) {
+	ci := buildContextInfo(&Quote{MessageID: "ABC123"})
+
+	if ci.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ci.GetStanzaID())
+	}
+	if ci.Participant != nil {
+		t.Fatalf("expected no participant, got %q", ci.GetParticipant())
+	}
+	if ci.QuotedMessage != nil {
+		t.Fatalf("expected no quotedMessage, got %v", ci.QuotedMessage)
+	}
+}
+
+func TestBuildContextInfoWithContentAndParticipant(t *testing.T) {
+	participant, err := types.ParseJID("5511999999999@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("failed to parse participant JID: %v", err)
+	}
+
+	ci := buildContextInfo(&Quote{
+		MessageID:   "ABC123",
+		Message:     "original text",
+		Participant: &participant,
+	})
+
+	if ci.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ci.GetStanzaID())
+	}
+	if ci.GetParticipant() != participant.String() {
+		t.Fatalf("expected participant=%q, got %q", participant.String(), ci.GetParticipant())
+	}
+	if ci.QuotedMessage == nil || ci.QuotedMessage.GetConversation() != "original text" {
+		t.Fatalf("expected quotedMessage conversation=%q, got %v", "original text", ci.QuotedMessage)
+	}
+}
+
+func TestBuildContactMessageWithQuote(t *testing.T) {
+	// Mirrors SendContact's single-contact branch (send_more.go): the ContextInfo
+	// must be attached to the ContactMessage and survive proto marshaling.
+	contact := contactToProto(SendContactItem{FullName: "Ivo Silva", PhoneNumber: "5511999997777"})
+	contact.ContextInfo = buildContextInfo(&Quote{MessageID: "ABC123", Message: "h"})
+	msg := &waE2E.Message{ContactMessage: contact}
+
+	ci := msg.ContactMessage.GetContextInfo()
+	if ci == nil {
+		t.Fatal("expected ContextInfo on ContactMessage")
+	}
+	if ci.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ci.GetStanzaID())
+	}
+	if ci.QuotedMessage == nil || ci.QuotedMessage.GetConversation() != "h" {
+		t.Fatalf("expected quotedMessage conversation=%q, got %v", "h", ci.QuotedMessage)
+	}
+
+	if _, err := proto.Marshal(msg); err != nil {
+		t.Fatalf("expected message to marshal, got %v", err)
 	}
 }

--- a/lib/whatsmiau/send_test.go
+++ b/lib/whatsmiau/send_test.go
@@ -1,0 +1,105 @@
+package whatsmiau
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildSendTextMessageWithoutQuote(t *testing.T) {
+	msg := buildSendTextMessage(&SendText{Text: "hello"})
+
+	if msg.Conversation == nil || msg.GetConversation() != "hello" {
+		t.Fatalf("expected Conversation=%q, got %v", "hello", msg.Conversation)
+	}
+	if msg.ExtendedTextMessage != nil {
+		t.Fatalf("expected no ExtendedTextMessage, got %v", msg.ExtendedTextMessage)
+	}
+}
+
+func TestBuildSendTextMessageQuoteIDOnly(t *testing.T) {
+	msg := buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})
+
+	ext := msg.ExtendedTextMessage
+	if ext == nil {
+		t.Fatal("expected ExtendedTextMessage for quoted message")
+	}
+	if ext.GetText() != "reply" {
+		t.Fatalf("expected text=%q, got %q", "reply", ext.GetText())
+	}
+	if ext.ContextInfo == nil {
+		t.Fatal("expected ContextInfo")
+	}
+	if ext.ContextInfo.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ext.ContextInfo.GetStanzaID())
+	}
+	if ext.ContextInfo.Participant != nil {
+		t.Fatalf("expected no participant, got %q", ext.ContextInfo.GetParticipant())
+	}
+	if ext.ContextInfo.QuotedMessage != nil {
+		t.Fatalf("expected no quotedMessage, got %v", ext.ContextInfo.QuotedMessage)
+	}
+}
+
+func TestBuildSendTextMessageQuoteWithConversation(t *testing.T) {
+	msg := buildSendTextMessage(&SendText{
+		Text:           "reply",
+		QuoteMessageID: "ABC123",
+		QuoteMessage:   "original text",
+	})
+
+	if msg.ExtendedTextMessage == nil {
+		t.Fatal("expected ExtendedTextMessage for quoted message")
+	}
+	ci := msg.ExtendedTextMessage.ContextInfo
+	if ci.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ci.GetStanzaID())
+	}
+	if ci.QuotedMessage == nil || ci.QuotedMessage.GetConversation() != "original text" {
+		t.Fatalf("expected quotedMessage conversation=%q, got %v", "original text", ci.QuotedMessage)
+	}
+}
+
+func TestBuildSendTextMessageQuoteWithParticipant(t *testing.T) {
+	participant, err := types.ParseJID("5511999999999@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("failed to parse participant JID: %v", err)
+	}
+
+	msg := buildSendTextMessage(&SendText{
+		Text:           "reply",
+		QuoteMessageID: "ABC123",
+		QuoteMessage:   "original text",
+		Participant:    &participant,
+	})
+
+	if msg.ExtendedTextMessage == nil {
+		t.Fatal("expected ExtendedTextMessage for quoted message")
+	}
+	ci := msg.ExtendedTextMessage.ContextInfo
+	if ci.GetStanzaID() != "ABC123" {
+		t.Fatalf("expected stanzaID=ABC123, got %q", ci.GetStanzaID())
+	}
+	if ci.GetParticipant() != participant.String() {
+		t.Fatalf("expected participant=%q, got %q", participant.String(), ci.GetParticipant())
+	}
+	if ci.QuotedMessage == nil {
+		t.Fatal("expected quotedMessage")
+	}
+}
+
+func TestBuildSendTextMessageQuoteTextPreserved(t *testing.T) {
+	// The reply text must go into ExtendedTextMessage.Text, not Conversation.
+	msg := buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})
+
+	if msg.GetConversation() != "" {
+		t.Fatalf("expected no Conversation field, got %q", msg.GetConversation())
+	}
+	if msg.ExtendedTextMessage.GetText() != "reply" {
+		t.Fatalf("expected text=%q, got %q", "reply", msg.ExtendedTextMessage.GetText())
+	}
+	if !proto.Equal(msg, buildSendTextMessage(&SendText{Text: "reply", QuoteMessageID: "ABC123"})) {
+		t.Fatal("expected deterministic message construction")
+	}
+}

--- a/server/controllers/helper.go
+++ b/server/controllers/helper.go
@@ -5,7 +5,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
 	"github.com/verbeux-ai/whatsmiau/models"
+	"github.com/verbeux-ai/whatsmiau/server/dto"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -88,4 +90,23 @@ func splitHostPort(h string) (string, string, error) {
 		return "", "", fmt.Errorf("expected host:port, got %s", h)
 	}
 	return parts[0], parts[1], nil
+}
+
+func buildQuote(q *dto.MessageRequestQuoted) (*whatsmiau.Quote, error) {
+	if q == nil || len(q.Key.Id) == 0 {
+		return nil, nil
+	}
+
+	quote := &whatsmiau.Quote{
+		MessageID: q.Key.Id,
+		Message:   q.Message.Conversation,
+	}
+	if q.Key.Participant != "" {
+		p, err := numberToJid(q.Key.Participant)
+		if err != nil {
+			return nil, fmt.Errorf("invalid quoted participant format")
+		}
+		quote.Participant = p
+	}
+	return quote, nil
 }

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -62,23 +62,17 @@ func (s *Message) SendText(ctx echo.Context) error {
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	sendText := &whatsmiau.SendText{
 		Text:       request.Text,
 		InstanceID: request.InstanceID,
 		RemoteJID:  jid,
-	}
-
-	if request.Quoted != nil && len(request.Quoted.Key.Id) > 0 {
-		sendText.QuoteMessageID = request.Quoted.Key.Id
-		sendText.QuoteMessage = request.Quoted.Message.Conversation
-		if request.Quoted.Key.Participant != "" {
-			p, err := numberToJid(request.Quoted.Key.Participant)
-			if err != nil {
-				zap.L().Error("error converting quoted participant to jid", zap.Error(err))
-				return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
-			}
-			sendText.Participant = p
-		}
+		Quote:      quote,
 	}
 
 	c := ctx.Request().Context()
@@ -145,15 +139,17 @@ func (s *Message) SendAudio(ctx echo.Context) error {
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	sendText := &whatsmiau.SendAudioRequest{
 		AudioURL:   request.Audio,
 		InstanceID: request.InstanceID,
 		RemoteJID:  jid,
-	}
-
-	if request.Quoted != nil && len(request.Quoted.Key.Id) > 0 && len(request.Quoted.Message.Conversation) > 0 {
-		sendText.QuoteMessage = request.Quoted.Message.Conversation
-		sendText.QuoteMessageID = request.Quoted.Key.Id
+		Quote:      quote,
 	}
 
 	c := ctx.Request().Context()
@@ -256,6 +252,12 @@ func (s *Message) sendDocument(ctx echo.Context, request dto.SendDocumentRequest
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	sendData := &whatsmiau.SendDocumentRequest{
 		InstanceID: request.InstanceID,
 		MediaURL:   request.Media,
@@ -263,6 +265,7 @@ func (s *Message) sendDocument(ctx echo.Context, request dto.SendDocumentRequest
 		FileName:   request.FileName,
 		RemoteJID:  jid,
 		Mimetype:   request.Mimetype,
+		Quote:      quote,
 	}
 
 	c := ctx.Request().Context()
@@ -321,12 +324,19 @@ func (s *Message) sendImage(ctx echo.Context, request dto.SendDocumentRequest) e
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	sendData := &whatsmiau.SendImageRequest{
 		InstanceID: request.InstanceID,
 		MediaURL:   request.Media,
 		Caption:    request.Caption,
 		RemoteJID:  jid,
 		Mimetype:   request.Mimetype,
+		Quote:      quote,
 	}
 
 	c := ctx.Request().Context()

--- a/server/controllers/message.go
+++ b/server/controllers/message.go
@@ -68,9 +68,17 @@ func (s *Message) SendText(ctx echo.Context) error {
 		RemoteJID:  jid,
 	}
 
-	if request.Quoted != nil && len(request.Quoted.Key.Id) > 0 && len(request.Quoted.Message.Conversation) > 0 {
-		sendText.QuoteMessage = request.Quoted.Message.Conversation
+	if request.Quoted != nil && len(request.Quoted.Key.Id) > 0 {
 		sendText.QuoteMessageID = request.Quoted.Key.Id
+		sendText.QuoteMessage = request.Quoted.Message.Conversation
+		if request.Quoted.Key.Participant != "" {
+			p, err := numberToJid(request.Quoted.Key.Participant)
+			if err != nil {
+				zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+				return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+			}
+			sendText.Participant = p
+		}
 	}
 
 	c := ctx.Request().Context()

--- a/server/controllers/message_more.go
+++ b/server/controllers/message_more.go
@@ -47,6 +47,12 @@ func (s *Message) sendVideo(ctx echo.Context, request dto.SendDocumentRequest, g
 		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	sendData := &whatsmiau.SendVideoRequest{
 		InstanceID:  request.InstanceID,
 		MediaURL:    request.Media,
@@ -54,6 +60,7 @@ func (s *Message) sendVideo(ctx echo.Context, request dto.SendDocumentRequest, g
 		RemoteJID:   jid,
 		Mimetype:    request.Mimetype,
 		GifPlayback: gif,
+		Quote:       quote,
 	}
 
 	c := ctx.Request().Context()
@@ -119,10 +126,17 @@ func (s *Message) SendPtv(ctx echo.Context) error {
 		time.Sleep(time.Millisecond * time.Duration(request.Delay))
 	}
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	res, err := s.whatsmiau.SendPtv(c, &whatsmiau.SendPtvRequest{
 		InstanceID: request.InstanceID,
 		VideoURL:   request.Video,
 		RemoteJID:  jid,
+		Quote:      quote,
 	})
 	if err != nil {
 		zap.L().Error("Whatsmiau.SendPtv failed", zap.Error(err))
@@ -176,10 +190,17 @@ func (s *Message) SendSticker(ctx echo.Context) error {
 	c := ctx.Request().Context()
 	time.Sleep(time.Millisecond * time.Duration(request.Delay))
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	res, err := s.whatsmiau.SendSticker(c, &whatsmiau.SendStickerRequest{
 		InstanceID: request.InstanceID,
 		StickerURL: request.Sticker,
 		RemoteJID:  jid,
+		Quote:      quote,
 	})
 	if err != nil {
 		zap.L().Error("Whatsmiau.SendSticker failed", zap.Error(err))
@@ -233,6 +254,12 @@ func (s *Message) SendLocation(ctx echo.Context) error {
 	c := ctx.Request().Context()
 	time.Sleep(time.Millisecond * time.Duration(request.Delay))
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	res, err := s.whatsmiau.SendLocation(c, &whatsmiau.SendLocationRequest{
 		InstanceID: request.InstanceID,
 		RemoteJID:  jid,
@@ -240,6 +267,7 @@ func (s *Message) SendLocation(ctx echo.Context) error {
 		Longitude:  request.Longitude,
 		Name:       request.Name,
 		Address:    request.Address,
+		Quote:      quote,
 	})
 	if err != nil {
 		zap.L().Error("Whatsmiau.SendLocation failed", zap.Error(err))
@@ -305,10 +333,17 @@ func (s *Message) SendContact(ctx echo.Context) error {
 	c := ctx.Request().Context()
 	time.Sleep(time.Millisecond * time.Duration(request.Delay))
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	res, err := s.whatsmiau.SendContact(c, &whatsmiau.SendContactRequest{
 		InstanceID: request.InstanceID,
 		RemoteJID:  jid,
 		Contacts:   contacts,
+		Quote:      quote,
 	})
 	if err != nil {
 		zap.L().Error("Whatsmiau.SendContact failed", zap.Error(err))
@@ -367,12 +402,19 @@ func (s *Message) SendPoll(ctx echo.Context) error {
 	c := ctx.Request().Context()
 	time.Sleep(time.Millisecond * time.Duration(request.Delay))
 
+	quote, err := buildQuote(request.Quoted)
+	if err != nil {
+		zap.L().Error("error converting quoted participant to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid quoted participant format")
+	}
+
 	res, err := s.whatsmiau.SendPoll(c, &whatsmiau.SendPollRequest{
 		InstanceID:      request.InstanceID,
 		RemoteJID:       jid,
 		Name:            request.Name,
 		SelectableCount: request.SelectableCount,
 		Values:          request.Values,
+		Quote:           quote,
 	})
 	if err != nil {
 		zap.L().Error("Whatsmiau.SendPoll failed", zap.Error(err))

--- a/server/dto/message.go
+++ b/server/dto/message.go
@@ -17,7 +17,10 @@ type MessageRequestQuoted struct {
 }
 
 type QuotedKey struct {
-	Id string `json:"id,omitempty"`
+	Id          string `json:"id,omitempty"`
+	RemoteJid   string `json:"remoteJid,omitempty"`
+	FromMe      bool   `json:"fromMe,omitempty"`
+	Participant string `json:"participant,omitempty"`
 }
 
 type QuotedMessage struct {


### PR DESCRIPTION
  ## Description
 Extends the quoted reply (reply-to) support from sendText to every send route: audio, document, image, video, ptv, sticker, location, contact, and poll.

**Request example with quoted:**                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                    
  ```json                                                                                                                                                                                                                           
  POST /v1/message/sendText/{instance}
  {
    "number": "558599999999@s.whatsapp.net",
    "text": "This is the reply",
    "quoted": {
      "key": {
        "id": "3EB0C0C7B4A2E5D8F1A6A7B8C9D0E",
        "participant": "55859909090@s.whatsapp.net"
      },
    }
  } 
```

  ## Checklist
  - [x] Code follows project standards
  - [ ] Documentation updated (if applicable)
  - [x] Tests executed successfully