### PR TITLE
fix: use SetGroupTopic for group description updates

### DIFF
--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -225,7 +225,7 @@ func (s *Whatsmiau) SetGroupDescription(ctx context.Context, req *SetGroupDescri
 	if !ok {
 		return whatsmeow.ErrClientIsNil
 	}
-	return client.SetGroupDescription(ctx, *req.GroupJID, req.Description)
+	return client.SetGroupTopic(ctx, *req.GroupJID, "", "", req.Description)
 }
 
 // ---------- FindGroup ----------


### PR DESCRIPTION
  ## Description
Fixes intermittent 409 conflict when updating a group description. The core was calling SetGroupDescription, which sends the description IQ without the prev/id attributes, so WhatsApp's server rejected stale-state edits with 409 conflict. SetGroupTopic (the fork's official method) adds those attributes and also correctly clears the description with delete="true" when empty. 

  ## Checklist
  - [x] Code follows project standards
  - [ ] Documentation updated (if applicable)
  - [x] Tests executed successfully