### PR TITLE
fix: update whatsmeow group description handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.0
+replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
 github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/verbeux-ai/whatsmeow v1.3.0 h1:wkjO90Tb5L1EBtUl+rwu7XJ+w19XAUa+5bdBdSETFA4=
-github.com/verbeux-ai/whatsmeow v1.3.0/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
+github.com/verbeux-ai/whatsmeow v1.3.1 h1:/8+NsxhSK8dFSK1IzqVG7hdpjwgMaS6qwSTh9godjqI=
+github.com/verbeux-ai/whatsmeow v1.3.1/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -225,7 +225,7 @@ func (s *Whatsmiau) SetGroupDescription(ctx context.Context, req *SetGroupDescri
 	if !ok {
 		return whatsmeow.ErrClientIsNil
 	}
-	return client.SetGroupTopic(ctx, *req.GroupJID, "", "", req.Description)
+	return client.SetGroupDescription(ctx, *req.GroupJID, req.Description)
 }
 
 // ---------- FindGroup ----------


### PR DESCRIPTION
Updates the WhatsMeow fork dependency from v1.3.0 to v1.3.1 and routes description updates through the corrected SetGroupDescription implementation.\n\nFork release: https://github.com/verbeux-ai/whatsmeow/releases/tag/v1.3.1\nFork fix: https://github.com/verbeux-ai/whatsmeow/pull/2\nUpstream issue: https://github.com/tulir/whatsmeow/issues/917\n\nValidation:\n- go test ./...\n- go build ./...\n- go vet ./...