### PR TITLE
fix: update community description handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.1
+replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
 github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/verbeux-ai/whatsmeow v1.3.1 h1:/8+NsxhSK8dFSK1IzqVG7hdpjwgMaS6qwSTh9godjqI=
-github.com/verbeux-ai/whatsmeow v1.3.1/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
+github.com/verbeux-ai/whatsmeow v1.3.2 h1:E4mGr4u8JfwRqLf65biHPiwsgECkK6GsFytrXkN+Wdw=
+github.com/verbeux-ai/whatsmeow v1.3.2/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
Updates the WhatsMeow fork dependency to v1.3.2, which detects parent communities and emits the same description-update IQ semantics and legacy ID format used by Baileys.\n\nFork release: https://github.com/verbeux-ai/whatsmeow/releases/tag/v1.3.2\nFork PR: https://github.com/verbeux-ai/whatsmeow/pull/3\nBaileys reference: https://github.com/WhiskeySockets/Baileys/blob/0af2386292907f7d9742d8d41f830d8c48208fa1/src/Socket/communities.ts#L304-L317\n\nDouble checks:\n- downloaded module files match the v1.3.2 tag blob hashes\n- go test ./...\n- go build ./...\n- go vet ./...