### PR TITLE
fix: resolve community descriptions through parent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.2
+replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
 github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/verbeux-ai/whatsmeow v1.3.2 h1:E4mGr4u8JfwRqLf65biHPiwsgECkK6GsFytrXkN+Wdw=
-github.com/verbeux-ai/whatsmeow v1.3.2/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
+github.com/verbeux-ai/whatsmeow v1.3.3 h1:nIP49DM1yLNKzMZHKERXbTfrNdtWBU53adranHW2OCU=
+github.com/verbeux-ai/whatsmeow v1.3.3/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/tests/integration/community_test.go
+++ b/tests/integration/community_test.go
@@ -14,6 +14,7 @@ import (
 // criação, subgrupos, link/unlink, configurações de join e participantes.
 func TestCommunityFlow(t *testing.T) {
 	var communityJID string
+	var announcementJID string
 	var subGroupJID string
 
 	t.Run("CreateCommunity", func(t *testing.T) {
@@ -61,9 +62,77 @@ func TestCommunityFlow(t *testing.T) {
 		defer drainClose(resp)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		var groups []map[string]any
+		var groups []struct {
+			ID                string `json:"id"`
+			IsDefaultSubGroup bool   `json:"isDefaultSubGroup"`
+		}
 		mustDecode(t, resp, &groups)
 		require.NotEmpty(t, groups, "comunidade deve ter ao menos o grupo de anúncios")
+		for _, group := range groups {
+			if group.IsDefaultSubGroup {
+				announcementJID = group.ID
+				break
+			}
+		}
+		require.NotEmpty(t, announcementJID, "comunidade deve informar o JID do grupo de anúncios")
+	})
+
+	readGroupDescription := func(t *testing.T, groupJID string) string {
+		t.Helper()
+		resp := do(t, http.MethodGet, groupURLQuery(t, "findGroupInfos", "groupJid="+groupJID), nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var info struct {
+			Description string `json:"desc"`
+		}
+		mustDecode(t, resp, &info)
+		return info.Description
+	}
+
+	t.Run("UpdateDescriptionViaCommunityParent", func(t *testing.T) {
+		const description = "Descrição atualizada diretamente no parent"
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupDescription"), map[string]any{
+			"groupJid":    communityJID,
+			"description": description,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.Equal(t, description, readGroupDescription(t, communityJID))
+	})
+
+	cooldown()
+
+	t.Run("UpdateDescriptionViaAnnouncementResolvesParent", func(t *testing.T) {
+		if announcementJID == "" {
+			t.Skip("SubGroups não retornou o grupo de anúncios")
+		}
+		const description = "Descrição atualizada usando o JID de avisos"
+		announcementDescription := readGroupDescription(t, announcementJID)
+
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupDescription"), map[string]any{
+			"groupJid":    announcementJID,
+			"description": description,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.Equal(t, description, readGroupDescription(t, communityJID))
+		assert.Equal(t, announcementDescription, readGroupDescription(t, announcementJID),
+			"descrição própria do grupo de avisos não deve ser alterada")
+	})
+
+	cooldown()
+
+	t.Run("UpdateDescriptionAgainViaAnnouncement", func(t *testing.T) {
+		if announcementJID == "" {
+			t.Skip("SubGroups não retornou o grupo de anúncios")
+		}
+		const description = "Segunda descrição atualizada usando o JID de avisos"
+		resp := do(t, http.MethodPost, groupURL(t, "updateGroupDescription"), map[string]any{
+			"groupJid":    announcementJID,
+			"description": description,
+		})
+		defer drainClose(resp)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.Equal(t, description, readGroupDescription(t, communityJID))
 	})
 
 	t.Run("LinkedGroupsParticipants", func(t *testing.T) {
@@ -157,7 +226,6 @@ func TestCommunityFlow(t *testing.T) {
 			"linkGroup deve retornar 200 ou 403, got %d", resp.StatusCode)
 	})
 }
-
 
 // TestCommunityValidation cobre rejeições esperadas nos endpoints de comunidade.
 func TestCommunityValidation(t *testing.T) {


### PR DESCRIPTION
Summary:
- update the whatsmeow fork dependency from v1.3.2 to v1.3.3
- preserve the existing updateGroupDescription routes and request shape
- extend the community integration flow to cover direct parent updates, announcement-JID aliasing, and a second update using fresh prev metadata

Fork:
- https://github.com/verbeux-ai/whatsmeow/pull/4
- https://github.com/verbeux-ai/whatsmeow/releases/tag/v1.3.3

Validation:
- go test ./...
- go test -race ./...
- go build ./...
- go vet ./...
- go test -tags=integration ./tests/integration -run ^$