### PR TITLE
fix: create communities with atomic descriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.3
+replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
 github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/verbeux-ai/whatsmeow v1.3.3 h1:nIP49DM1yLNKzMZHKERXbTfrNdtWBU53adranHW2OCU=
-github.com/verbeux-ai/whatsmeow v1.3.3/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
+github.com/verbeux-ai/whatsmeow v1.3.4 h1:lQsBKBP6/hERdKhQrl6FSRB0LmHDnFUsA26Ui/bmLeE=
+github.com/verbeux-ai/whatsmeow v1.3.4/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -574,19 +574,14 @@ func (s *Whatsmiau) CreateCommunity(ctx context.Context, req *CreateCommunityReq
 	}
 
 	created, err := client.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
-		Name: req.Subject,
+		Name:        req.Subject,
+		Description: req.Description,
 		GroupParent: types.GroupParent{
 			IsParent: true,
 		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create community: %w", err)
-	}
-
-	if req.Description != "" {
-		if err := client.SetGroupDescription(ctx, created.JID, req.Description); err != nil {
-			zap.L().Warn("community created but failed to set description", zap.Error(err), zap.String("community", created.JID.String()))
-		}
 	}
 
 	info, err := client.GetGroupInfo(ctx, created.JID)

--- a/tests/integration/community_test.go
+++ b/tests/integration/community_test.go
@@ -18,9 +18,10 @@ func TestCommunityFlow(t *testing.T) {
 	var subGroupJID string
 
 	t.Run("CreateCommunity", func(t *testing.T) {
+		const initialDescription = "Comunidade de testes automatizados"
 		resp := do(t, http.MethodPost, communityURL(t, "create"), map[string]any{
 			"subject":     "WhatsMiau Community Test",
-			"description": "Comunidade de testes automatizados",
+			"description": initialDescription,
 		})
 		defer drainClose(resp)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -33,6 +34,7 @@ func TestCommunityFlow(t *testing.T) {
 
 		isCommunity, _ := body["isCommunity"].(bool)
 		assert.True(t, isCommunity, "isCommunity deve ser true para comunidades")
+		assert.Equal(t, initialDescription, body["desc"], "descrição deve ser definida durante a criação")
 	})
 
 	if communityJID == "" {


### PR DESCRIPTION
## Summary

- update the whatsmeow fork from v1.3.3 to v1.3.4
- pass the community description into the parent create IQ
- remove the follow-up description update from community creation
- assert the initial description in the integration flow

## Why

The upstream group creation defaults added to v1.3.3 are valid for ordinary groups but WhatsApp rejects them when mixed into a community parent payload with IQ 400 bad-request. The follow-up description write also made creation vulnerable to timing conflicts and rate limits.

The fork v1.3.4 uses a dedicated parent payload and supports the description inline, so the existing API route stays unchanged while creation becomes one atomic protocol operation.

## Live verification

- reproduced the original 400 using v1.3.3
- created a parent successfully after separating the payload
- confirmed the automatic default announcement subgroup
- created a community with description through the public route
- confirmed the description in the create response and a fresh metadata query
- confirmed description updates through parent and announcement JIDs still target the parent

## Tests

- go test ./...
- go test -tags=integration -run ^$ ./tests/integration
- fork CI passed on current and legacy Go jobs