### PR TITLE
perf: connect loaded sessions in parallel

### DIFF
--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -49,6 +49,25 @@ type Whatsmiau struct {
 var instance *Whatsmiau
 var mu = &sync.Mutex{}
 
+const loadMiauConnectConcurrency = 10
+
+func runLoadMiauTasks[T any](items []T, task func(T)) {
+	semaphore := make(chan struct{}, loadMiauConnectConcurrency)
+	var wg sync.WaitGroup
+
+	for _, item := range items {
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go func(item T) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			task(item)
+		}(item)
+	}
+
+	wg.Wait()
+}
+
 func Get() *Whatsmiau {
 	mu.Lock()
 	defer mu.Unlock()
@@ -98,6 +117,7 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 	callBridges := xsync.NewMap[string, *callBridge]()
 
 	clientLog := waLog.Stdout("Client", level, false)
+	clientsToConnect := make([]*whatsmeow.Client, 0, len(deviceStore))
 	for _, device := range deviceStore {
 		client := whatsmeow.NewClient(device, clientLog)
 		if client.Store.ID == nil {
@@ -112,13 +132,7 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 				callClients.Store(instanceFound.ID, meowcaller.NewClient(client))
 			}
 			clients.Store(instanceFound.ID, client)
-			if err := client.Connect(); err != nil {
-				jid := ""
-				if client.Store != nil && client.Store.ID != nil {
-					jid = client.Store.ID.String()
-				}
-				zap.L().Error("failed to connect connected device", zap.Error(err), zap.String("jid", jid))
-			}
+			clientsToConnect = append(clientsToConnect, client)
 			continue
 		}
 
@@ -135,6 +149,16 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 			}
 		}
 	}
+
+	runLoadMiauTasks(clientsToConnect, func(client *whatsmeow.Client) {
+		if err := client.Connect(); err != nil {
+			jid := ""
+			if client.Store != nil && client.Store.ID != nil {
+				jid = client.Store.ID.String()
+			}
+			zap.L().Error("failed to connect connected device", zap.Error(err), zap.String("jid", jid))
+		}
+	})
 
 	var storage interfaces.Storage
 	if env.Env.GCSEnabled {

--- a/lib/whatsmiau/whatsmeow_load_test.go
+++ b/lib/whatsmiau/whatsmeow_load_test.go
@@ -1,0 +1,79 @@
+package whatsmiau
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunLoadMiauTasksLimitsConcurrencyAndWaits(t *testing.T) {
+	total := loadMiauConnectConcurrency + 5
+	items := make([]int, total)
+	started := make(chan struct{}, total)
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	var stateMu sync.Mutex
+	active := 0
+	maxActive := 0
+	completed := 0
+
+	go func() {
+		runLoadMiauTasks(items, func(int) {
+			stateMu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			stateMu.Unlock()
+
+			started <- struct{}{}
+			<-release
+
+			stateMu.Lock()
+			active--
+			completed++
+			stateMu.Unlock()
+		})
+		close(done)
+	}()
+
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	for range loadMiauConnectConcurrency {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for initial tasks")
+		}
+	}
+
+	select {
+	case <-started:
+		t.Fatalf("more than %d tasks started concurrently", loadMiauConnectConcurrency)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	released = true
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for all tasks to complete")
+	}
+
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	if maxActive != loadMiauConnectConcurrency {
+		t.Fatalf("expected max concurrency %d, got %d", loadMiauConnectConcurrency, maxActive)
+	}
+	if completed != total {
+		t.Fatalf("expected %d completed tasks, got %d", total, completed)
+	}
+}


### PR DESCRIPTION
## Summary

- connect restored WhatsApp sessions in parallel during LoadMiau
- cap startup connections at 10 simultaneous handshakes
- keep orphan cleanup, singleton publication, event handlers, and startup readiness behavior unchanged

## Validation

- go test -count=1 ./...
- go vet ./...
- go test -race -count=1 ./lib/whatsmiau
- concurrency test repeated 50 times