### PR TITLE
fix: update participants in community parents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,4 +127,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.4
+replace go.mau.fi/whatsmeow => github.com/verbeux-ai/whatsmeow v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
 github.com/vektah/gqlparser/v2 v2.5.27/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/verbeux-ai/whatsmeow v1.3.4 h1:lQsBKBP6/hERdKhQrl6FSRB0LmHDnFUsA26Ui/bmLeE=
-github.com/verbeux-ai/whatsmeow v1.3.4/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
+github.com/verbeux-ai/whatsmeow v1.3.5 h1:eRgne92UOAvxVlkrzif2uC1JvRVpqAKY5U/DBotZ3yc=
+github.com/verbeux-ai/whatsmeow v1.3.5/go.mod h1:EklsRqbr16Wp1fGKJMN7m0YUDpGqYt53UQ/+/1dP8yo=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -491,7 +491,7 @@ func (s *Whatsmiau) UpdateGroupParticipant(ctx context.Context, req *UpdateParti
 		return nil, err
 	}
 
-	participants, err := client.UpdateGroupParticipants(ctx, *req.GroupJID, jids, action)
+	participants, err := client.UpdateGroupParticipantsWithCommunity(ctx, *req.GroupJID, jids, action)
 	if err != nil {
 		return nil, err
 	}

--- a/server/controllers/group.go
+++ b/server/controllers/group.go
@@ -585,7 +585,13 @@ func (s *Group) UpdateParticipant(ctx echo.Context) error {
 		Participants: request.Participants,
 	})
 	if err != nil {
-		zap.L().Error("Whatsmiau.UpdateGroupParticipant failed", zap.Error(err))
+		zap.L().Error("Whatsmiau.UpdateGroupParticipant failed",
+			zap.Error(err),
+			zap.String("instance", request.InstanceID),
+			zap.String("group_jid", request.GroupJid),
+			zap.String("action", request.Action),
+			zap.Int("participant_count", len(request.Participants)),
+		)
 		code, msg := mapGroupError(err)
 		return utils.HTTPFail(ctx, code, err, msg)
 	}


### PR DESCRIPTION
## Summary
- update the whatsmeow fork dependency to v1.3.5
- keep the existing updateParticipant routes and payloads unchanged
- use community-aware participant updates internally
- add sanitized action, group and participant-count context to failures

## Behavior
- community parent add resolves and targets the default announcement group
- community parent remove targets the parent with linked_groups=true
- promote and demote target the parent
- ordinary and announcement groups keep the existing generic behavior

## Verification
- go test ./...
- live test using published v1.3.5: parent add returned HTTP 201 and a participant-level 403 instead of IQ 400
- protocol log confirmed the add IQ targeted the announcement group
- removal test confirmed linked_groups=true on the parent

Core PR: https://github.com/verbeux-ai/whatsmeow/pull/6
Release: https://github.com/verbeux-ai/whatsmeow/releases/tag/v1.3.5