### PR TITLE
fix: raise subject limit to 100 characters

### DIFF
--- a/server/dto/community.go
+++ b/server/dto/community.go
@@ -2,13 +2,13 @@ package dto
 
 type CreateCommunityRequest struct {
 	InstanceID  string `param:"instance" validate:"required" swaggerignore:"true"`
-	Subject     string `json:"subject" validate:"required,min=1,max=25"`
+	Subject     string `json:"subject" validate:"required,min=1,max=100"`
 	Description string `json:"description,omitempty"`
 }
 
 type CreateCommunitySubGroupRequest struct {
 	InstanceID   string   `param:"instance" validate:"required" swaggerignore:"true"`
-	Subject      string   `json:"subject" validate:"required,min=1,max=25"`
+	Subject      string   `json:"subject" validate:"required,min=1,max=100"`
 	ParentJid    string   `json:"parentJid" validate:"required"`
 	Participants []string `json:"participants" validate:"omitempty,dive,required"`
 }

--- a/server/dto/group.go
+++ b/server/dto/group.go
@@ -2,7 +2,7 @@ package dto
 
 type CreateGroupRequest struct {
 	InstanceID          string   `param:"instance" validate:"required" swaggerignore:"true"`
-	Subject             string   `json:"subject" validate:"required,min=1,max=25"`
+	Subject             string   `json:"subject" validate:"required,min=1,max=100"`
 	Description         string   `json:"description,omitempty"`
 	Participants        []string `json:"participants" validate:"omitempty,dive,required"`
 	PromoteParticipants bool     `json:"promoteParticipants,omitempty"`
@@ -11,7 +11,7 @@ type CreateGroupRequest struct {
 type GroupSubjectRequest struct {
 	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
 	GroupJid   string `json:"groupJid" validate:"required"`
-	Subject    string `json:"subject" validate:"required,min=1,max=25"`
+	Subject    string `json:"subject" validate:"required,min=1,max=100"`
 }
 
 type GroupPictureRequest struct {


### PR DESCRIPTION
  ## Description
Raise subject validation limit from 25 to 100 characters across community, subgroup, and group create/rename DTOs.

  ## Checklist
  - [x] Code follows project standards
  - [ ] Documentation updated (if applicable)
  - [x] Tests executed successfully