### PR TITLE
feat: add group setMemberAddMode endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1247,6 +1247,94 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/group/setMemberAddMode/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/toggleEphemeral/{instance}": {
             "post": {
                 "security": [
@@ -4865,6 +4953,94 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/instance/{instance}/group/setMemberAddMode": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Mode payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/instance/{instance}/group/toggleEphemeral": {
             "post": {
                 "security": [
@@ -7680,6 +7856,27 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
+                }
+            }
+        },
+        "dto.GroupSetMemberAddModeRequest": {
+            "type": "object",
+            "required": [
+                "groupJid",
+                "mode"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "announcement",
+                        "not_announcement",
+                        "locked",
+                        "unlocked"
+                    ]
+                },
+                "groupJid": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -556,6 +556,25 @@
             ],
             "type": "object"
         },
+        "dto.GroupSetMemberAddModeRequest": {
+            "properties": {
+                "mode": {
+                    "enum": [
+                        "admin_add",
+                        "all_member_add"
+                    ],
+                    "type": "string"
+                },
+                "groupJid": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "groupJid",
+                "mode"
+            ],
+            "type": "object"
+        },
         "dto.GroupToggleEphemeralRequest": {
             "properties": {
                 "expiration": {
@@ -3659,6 +3678,101 @@
                     }
                 ],
                 "summary": "Send group invite link via text to phone numbers",
+                "tags": [
+                    "Group"
+                ]
+            }
+        },
+        "/v1/group/setMemberAddMode/{instance}": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "postV1GroupSetMemberAddModeByInstance",
+                "parameters": [
+                    {
+                        "description": "Instance ID",
+                        "in": "path",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "Mode payload",
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "additionalProperties": true,
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.AuthenticationErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
                 "tags": [
                     "Group"
                 ]
@@ -7598,6 +7712,101 @@
                     }
                 ],
                 "summary": "Send group invite link via text to phone numbers",
+                "tags": [
+                    "Group"
+                ]
+            }
+        },
+        "/v1/instance/{instance}/group/setMemberAddMode": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "postV1InstanceByInstanceGroupSetMemberAddMode",
+                "parameters": [
+                    {
+                        "description": "Instance ID",
+                        "in": "path",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "Mode payload",
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupSetMemberAddModeRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "additionalProperties": true,
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.AuthenticationErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Toggle who can add members (admins only or all)",
                 "tags": [
                     "Group"
                 ]

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -373,6 +373,19 @@ definitions:
     - groupJid
     - subject
     type: object
+  dto.GroupSetMemberAddModeRequest:
+    properties:
+      mode:
+        enum:
+        - admin_add
+        - all_member_add
+        type: string
+      groupJid:
+        type: string
+    required:
+    - groupJid
+    - mode
+    type: object
   dto.GroupToggleEphemeralRequest:
     properties:
       expiration:
@@ -2439,6 +2452,68 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send group invite link via text to phone numbers
+      tags:
+      - Group
+  /v1/group/setMemberAddMode/{instance}:
+    post:
+      consumes:
+      - application/json
+      operationId: postV1GroupSetMemberAddModeByInstance
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Mode payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSetMemberAddModeRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.AuthenticationErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "410":
+          description: Gone
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle who can add members (admins only or all)
       tags:
       - Group
   /v1/group/toggleEphemeral/{instance}:
@@ -4645,6 +4720,68 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send group invite link via text to phone numbers
+      tags:
+      - Group
+  /v1/instance/{instance}/group/setMemberAddMode:
+    post:
+      consumes:
+      - application/json
+      operationId: postV1InstanceByInstanceGroupSetMemberAddMode
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Mode payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupSetMemberAddModeRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.AuthenticationErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "410":
+          description: Gone
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Toggle who can add members (admins only or all)
       tags:
       - Group
   /v1/instance/{instance}/group/toggleEphemeral:

--- a/docs/swagger_contract_test.go
+++ b/docs/swagger_contract_test.go
@@ -35,10 +35,10 @@ func TestSwaggerCoversEveryDocumentedRoute(t *testing.T) {
 	}
 
 	operations := append(routes.DocumentedV1Operations(), routes.DocumentedDocumentationOperations()...)
-	if got, want := len(routes.DocumentedV1Operations()), 100; got != want {
+	if got, want := len(routes.DocumentedV1Operations()), 102; got != want {
 		t.Fatalf("unexpected /v1 operation inventory size: got %d, want %d", got, want)
 	}
-	if got, want := len(operations), 104; got != want {
+	if got, want := len(operations), 106; got != want {
 		t.Fatalf("unexpected full operation inventory size: got %d, want %d", got, want)
 	}
 

--- a/lib/whatsmiau/group.go
+++ b/lib/whatsmiau/group.go
@@ -764,6 +764,32 @@ func (s *Whatsmiau) SetCommunityJoinApprovalMode(ctx context.Context, req *SetJo
 	return client.SetGroupJoinApprovalMode(ctx, *req.CommunityJID, req.Mode)
 }
 
+// ---------- Group: Member add mode ----------
+
+type SetMemberAddModeRequest struct {
+	InstanceID string
+	GroupJID   *types.JID
+	Mode       string
+}
+
+func (s *Whatsmiau) SetGroupMemberAddMode(ctx context.Context, req *SetMemberAddModeRequest) error {
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return whatsmeow.ErrClientIsNil
+	}
+
+	var mode types.GroupMemberAddMode
+	switch req.Mode {
+	case "admin_add":
+		mode = types.GroupMemberAddModeAdmin
+	case "all_member_add":
+		mode = types.GroupMemberAddModeAllMember
+	default:
+		return fmt.Errorf("invalid mode: %s", req.Mode)
+	}
+	return client.SetGroupMemberAddMode(ctx, *req.GroupJID, mode)
+}
+
 type SetGroupAddModeRequest struct {
 	InstanceID  string
 	CommunityJID *types.JID

--- a/server/controllers/group.go
+++ b/server/controllers/group.go
@@ -604,6 +604,50 @@ func (s *Group) UpdateParticipant(ctx echo.Context) error {
 	return ctx.JSON(http.StatusCreated, resp)
 }
 
+// SetMemberAddMode godoc
+// @Summary      Toggle who can add members (admins only or all)
+// @Description  Accepts a regular group or subgroup JID. Community parent JIDs are rejected by WhatsApp.
+// @Tags         Group
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path  string true  "Instance ID"
+// @Param        body      body  dto.GroupSetMemberAddModeRequest true  "Mode payload"
+// @Success      201       {object}  map[string]interface{}
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      403       {object}  utils.HTTPErrorResponse
+// @Failure      404       {object}  utils.HTTPErrorResponse
+// @Failure      410       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      429       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /v1/instance/{instance}/group/setMemberAddMode [post]
+// @Router       /v1/group/setMemberAddMode/{instance} [post]
+func (s *Group) SetMemberAddMode(ctx echo.Context) error {
+	var request dto.GroupSetMemberAddModeRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+	groupJid, err := parseGroupJID(request.GroupJid)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid groupJid")
+	}
+
+	if err := s.whatsmiau.SetGroupMemberAddMode(ctx.Request().Context(), &whatsmiau.SetMemberAddModeRequest{
+		InstanceID: request.InstanceID,
+		GroupJID:   groupJid,
+		Mode:       request.Mode,
+	}); err != nil {
+		zap.L().Error("Whatsmiau.SetGroupMemberAddMode failed", zap.Error(err))
+		code, msg := mapGroupError(err)
+		return utils.HTTPFail(ctx, code, err, msg)
+	}
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{})
+}
+
 // UpdateSetting godoc
 // @Summary      Update group setting (announce/locked)
 // @Tags         Group

--- a/server/dto/group.go
+++ b/server/dto/group.go
@@ -62,6 +62,12 @@ type GroupUpdateSettingRequest struct {
 	Action     string `json:"action" validate:"required,oneof=announcement not_announcement locked unlocked"`
 }
 
+type GroupSetMemberAddModeRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	GroupJid   string `json:"groupJid" validate:"required"`
+	Mode       string `json:"mode" validate:"required,oneof=admin_add all_member_add"`
+}
+
 type GroupToggleEphemeralRequest struct {
 	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
 	GroupJid   string `json:"groupJid" validate:"required"`

--- a/server/routes/contracts.go
+++ b/server/routes/contracts.go
@@ -56,6 +56,7 @@ func DocumentedV1Operations() []Operation {
 		{http.MethodPost, "revokeInviteCode"},
 		{http.MethodPost, "updateParticipant"},
 		{http.MethodPost, "updateSetting"},
+		{http.MethodPost, "setMemberAddMode"},
 		{http.MethodPost, "toggleEphemeral"},
 		{http.MethodDelete, "leaveGroup"},
 	}

--- a/server/routes/group.go
+++ b/server/routes/group.go
@@ -26,6 +26,7 @@ func Group(group *echo.Group) {
 	group.POST("/revokeInviteCode", controller.RevokeInviteCode)
 	group.POST("/updateParticipant", controller.UpdateParticipant)
 	group.POST("/updateSetting", controller.UpdateSetting)
+	group.POST("/setMemberAddMode", controller.SetMemberAddMode)
 	group.POST("/toggleEphemeral", controller.ToggleEphemeral)
 	group.DELETE("/leaveGroup", controller.LeaveGroup)
 }
@@ -49,6 +50,7 @@ func GroupEVO(group *echo.Group) {
 	group.POST("/revokeInviteCode/:instance", controller.RevokeInviteCode)
 	group.POST("/updateParticipant/:instance", controller.UpdateParticipant)
 	group.POST("/updateSetting/:instance", controller.UpdateSetting)
+	group.POST("/setMemberAddMode/:instance", controller.SetMemberAddMode)
 	group.POST("/toggleEphemeral/:instance", controller.ToggleEphemeral)
 	group.DELETE("/leaveGroup/:instance", controller.LeaveGroup)
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
Add `POST group/setMemberAddMode` to control who can add members to a group (`admin_add/all_member_add`). Works on regular groups and subgroups; community parents are rejected by WhatsApp. Includes DTO, controller, lib method, contracts and swagger.
                                                                                                                                                                                                                                    
## Checklist

- [x] Code follows project standards
- [x] Documentation updated (if applicable)
- [x] Tests executed successfully   