### PR TITLE
feat: fetch profile picture url

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -212,6 +212,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/chat/fetchProfilePictureUrl/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the full-size profile picture URL for a number or group JID, mirroring Evolution API's POST /chat/fetchProfilePictureUrl. profilePictureUrl is null when the target has no picture or hid it.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Fetch profile picture URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Number or JID",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.FetchProfilePictureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.FetchProfilePictureResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/chat/markMessageAsRead/{instance}": {
             "post": {
                 "security": [
@@ -7824,6 +7888,28 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "senderTimestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.FetchProfilePictureRequest": {
+            "type": "object",
+            "required": [
+                "number"
+            ],
+            "properties": {
+                "number": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.FetchProfilePictureResponse": {
+            "type": "object",
+            "properties": {
+                "profilePictureUrl": {
+                    "type": "string"
+                },
+                "wuid": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -459,6 +459,28 @@
             },
             "type": "object"
         },
+        "dto.FetchProfilePictureRequest": {
+            "properties": {
+                "number": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "number"
+            ],
+            "type": "object"
+        },
+        "dto.FetchProfilePictureResponse": {
+            "properties": {
+                "profilePictureUrl": {
+                    "type": "string"
+                },
+                "wuid": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "dto.FindWebhookResponse": {
             "properties": {
                 "webhook": {
@@ -2598,6 +2620,77 @@
                     }
                 ],
                 "summary": "Delete message for everyone",
+                "tags": [
+                    "Chat"
+                ]
+            }
+        },
+        "/v1/chat/fetchProfilePictureUrl/{instance}": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "description": "Returns the full-size profile picture URL for a number or group JID, mirroring Evolution API's POST /chat/fetchProfilePictureUrl. profilePictureUrl is null when the target has no picture or hid it.",
+                "operationId": "postV1ChatFetchProfilePictureUrlByInstance",
+                "parameters": [
+                    {
+                        "description": "Instance ID",
+                        "in": "path",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "Number or JID",
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.FetchProfilePictureRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.FetchProfilePictureResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.AuthenticationErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Fetch profile picture URL",
                 "tags": [
                     "Chat"
                 ]

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -307,6 +307,20 @@ definitions:
       senderTimestamp:
         type: string
     type: object
+  dto.FetchProfilePictureRequest:
+    properties:
+      number:
+        type: string
+    required:
+    - number
+    type: object
+  dto.FetchProfilePictureResponse:
+    properties:
+      profilePictureUrl:
+        type: string
+      wuid:
+        type: string
+    type: object
   dto.FindWebhookResponse:
     properties:
       webhook:
@@ -1749,6 +1763,54 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Delete message for everyone
+      tags:
+      - Chat
+  /v1/chat/fetchProfilePictureUrl/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Returns the full-size profile picture URL for a number or group
+        JID, mirroring Evolution API's POST /chat/fetchProfilePictureUrl. profilePictureUrl
+        is null when the target has no picture or hid it.
+      operationId: postV1ChatFetchProfilePictureUrlByInstance
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Number or JID
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.FetchProfilePictureRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.FetchProfilePictureResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.AuthenticationErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Fetch profile picture URL
       tags:
       - Chat
   /v1/chat/markMessageAsRead/{instance}:

--- a/docs/swagger_contract_test.go
+++ b/docs/swagger_contract_test.go
@@ -35,10 +35,10 @@ func TestSwaggerCoversEveryDocumentedRoute(t *testing.T) {
 	}
 
 	operations := append(routes.DocumentedV1Operations(), routes.DocumentedDocumentationOperations()...)
-	if got, want := len(routes.DocumentedV1Operations()), 103; got != want {
+	if got, want := len(routes.DocumentedV1Operations()), 104; got != want {
 		t.Fatalf("unexpected /v1 operation inventory size: got %d, want %d", got, want)
 	}
-	if got, want := len(operations), 107; got != want {
+	if got, want := len(operations), 108; got != want {
 		t.Fatalf("unexpected full operation inventory size: got %d, want %d", got, want)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.22.0
 	google.golang.org/api v0.243.0
 	google.golang.org/protobuf v1.36.11
 	sigs.k8s.io/yaml v1.3.0
@@ -114,7 +115,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/lib/whatsmiau/chat.go
+++ b/lib/whatsmiau/chat.go
@@ -1,6 +1,7 @@
 package whatsmiau
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -162,4 +163,31 @@ func (s *Whatsmiau) DeleteMessageForEveryone(ctx context.Context, req *DeleteMes
 	msg := client.BuildRevoke(chat, sender, types.MessageID(req.MessageID))
 	_, err := client.SendMessage(ctx, chat, msg)
 	return err
+}
+
+// FetchProfilePictureURL returns the full-size ('image') profile picture URL
+// for a user or group JID, mirroring Evolution API's POST /chat/fetchProfilePictureUrl.
+// It returns ("", nil) when the target has no picture or hid its picture; the
+// caller maps that to a null field, keeping the contract Evolution-compatible.
+func (s *Whatsmiau) FetchProfilePictureURL(ctx context.Context, instanceID string, jid types.JID) (string, error) {
+	client, ok := s.clients.Load(instanceID)
+	if !ok {
+		return "", whatsmeow.ErrClientIsNil
+	}
+	if !client.IsConnected() {
+		return "", fmt.Errorf("client not connected")
+	}
+
+	pic, err := client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{Preview: false})
+	if errors.Is(err, whatsmeow.ErrProfilePictureNotSet) || errors.Is(err, whatsmeow.ErrProfilePictureUnauthorized) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if pic == nil || pic.URL == "" {
+		return "", nil
+	}
+
+	return pic.URL, nil
 }

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -12,7 +14,12 @@ import (
 	"github.com/verbeux-ai/whatsmiau/utils"
 	"go.mau.fi/whatsmeow/types"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
+
+// fetchPictureSingleFlight is package-level because both Chat and ChatEVO
+// instantiate their own Chat controller; the deduplication must be shared.
+var fetchPictureSingleFlight singleflight.Group
 
 type Chat struct {
 	repo      interfaces.InstanceRepository
@@ -307,4 +314,74 @@ func (s *Chat) UpdateMessage(ctx echo.Context) error {
 		MessageTimestamp: int(res.CreatedAt.Unix()),
 		InstanceId:       request.InstanceID,
 	})
+}
+
+// FetchProfilePicture godoc
+// @Summary      Fetch profile picture URL
+// @Description  Returns the full-size profile picture URL for a number or group JID, mirroring Evolution API's POST /chat/fetchProfilePictureUrl. profilePictureUrl is null when the target has no picture or hid it.
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                            true  "Instance ID"
+// @Param        body      body      dto.FetchProfilePictureRequest     true  "Number or JID"
+// @Success      200       {object}  dto.FetchProfilePictureResponse
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Router       /v1/chat/fetchProfilePictureUrl/{instance} [post]
+func (s *Chat) FetchProfilePicture(ctx echo.Context) error {
+	var request dto.FetchProfilePictureRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	number := request.Number
+	if !strings.Contains(number, "@") && len(number) >= 18 {
+		// A bare id that long cannot be a phone number (E.164 maxes at 15
+		// digits); it is a group id, mirroring Evolution's createJid.
+		number += "@" + types.GroupServer
+	}
+
+	jid, err := numberToJid(number)
+	if err != nil {
+		zap.L().Error("error converting number to jid", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number format")
+	}
+
+	// Reject JIDs whose server is not a known WhatsApp one before any
+	// network round-trip happens (ParseJID accepts arbitrary servers).
+	switch jid.Server {
+	case types.DefaultUserServer, types.GroupServer, types.HiddenUserServer, types.BroadcastServer:
+	default:
+		return utils.HTTPFail(ctx, http.StatusBadRequest, nil, "invalid jid server")
+	}
+
+	// Singleflight with a detached context: the shared whatsmeow call must not
+	// be canceled because one waiting request was aborted. In-process only —
+	// no cache, mirroring Evolution's per-request fetch.
+	sfCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	url, err, _ := fetchPictureSingleFlight.Do(request.InstanceID+":"+jid.String(), func() (interface{}, error) {
+		return s.whatsmiau.FetchProfilePictureURL(sfCtx, request.InstanceID, *jid)
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.FetchProfilePictureURL failed", zap.Error(err))
+		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to fetch profile picture")
+	}
+
+	return ctx.JSON(http.StatusOK, buildProfilePictureResponse(jid, url.(string)))
+}
+
+func buildProfilePictureResponse(jid *types.JID, url string) dto.FetchProfilePictureResponse {
+	resp := dto.FetchProfilePictureResponse{Wuid: jid.String()}
+	if url != "" {
+		resp.ProfilePictureUrl = &url
+	}
+	return resp
 }

--- a/server/dto/chat.go
+++ b/server/dto/chat.go
@@ -74,3 +74,15 @@ type UpdateMessageResponse struct {
 	MessageTimestamp int                     `json:"messageTimestamp"`
 	InstanceId       string                  `json:"instanceId"`
 }
+
+// FetchProfilePictureRequest mirrors Evolution API's POST /chat/fetchProfilePictureUrl
+// payload: the number or JID (user or group) whose profile picture URL is requested.
+type FetchProfilePictureRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	Number     string `json:"number" validate:"required"`
+}
+
+type FetchProfilePictureResponse struct {
+	Wuid              string  `json:"wuid"`
+	ProfilePictureUrl *string `json:"profilePictureUrl"`
+}

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -26,5 +26,6 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/sendPresence/:instance", controller.SendChatPresence)
 	group.POST("/whatsappNumbers/:instance", controller.NumberExists)
 	group.POST("/updateMessage/:instance", controller.UpdateMessage)
+	group.POST("/fetchProfilePictureUrl/:instance", controller.FetchProfilePicture)
 	group.DELETE("/deleteMessageForEveryone/:instance", controller.DeleteMessageForEveryone)
 }

--- a/server/routes/contracts.go
+++ b/server/routes/contracts.go
@@ -35,7 +35,7 @@ func DocumentedV1Operations() []Operation {
 		appendOperation(http.MethodPost, "/v1/message/"+action+"/{instance}")
 	}
 
-	appendOperation(http.MethodPost, "/v1/instance/{instance}/chat/presence", "/v1/instance/{instance}/chat/read-messages", "/v1/chat/markMessageAsRead/{instance}", "/v1/chat/sendPresence/{instance}", "/v1/chat/whatsappNumbers/{instance}", "/v1/chat/updateMessage/{instance}")
+	appendOperation(http.MethodPost, "/v1/instance/{instance}/chat/presence", "/v1/instance/{instance}/chat/read-messages", "/v1/chat/markMessageAsRead/{instance}", "/v1/chat/sendPresence/{instance}", "/v1/chat/whatsappNumbers/{instance}", "/v1/chat/updateMessage/{instance}", "/v1/chat/fetchProfilePictureUrl/{instance}")
 	appendOperation(http.MethodDelete, "/v1/instance/{instance}/chat/deleteMessageForEveryone", "/v1/chat/deleteMessageForEveryone/{instance}")
 
 	groupActions := []struct {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
Adds Evolution-compatible `POST /chat/fetchProfilePictureUrl/:instance`, returning the full-size profile picture URL for a user or group JID.
                                                                                                                                                         
                                      
                                                                                                                                                                                                                                    
## Checklist

- [x] Code follows project standards
- [x] Documentation updated (if applicable)
- [x] Tests executed successfully   