### PR TITLE
chore: remove unused readStatus config field

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -7637,9 +7637,6 @@ const docTemplate = `{
                 "readMessages": {
                     "type": "boolean"
                 },
-                "readStatus": {
-                    "type": "boolean"
-                },
                 "rejectCall": {
                     "type": "boolean"
                 },
@@ -7770,9 +7767,6 @@ const docTemplate = `{
                 "readMessages": {
                     "type": "boolean"
                 },
-                "readStatus": {
-                    "type": "boolean"
-                },
                 "rejectCall": {
                     "type": "boolean"
                 },
@@ -7824,9 +7818,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {
@@ -8128,9 +8119,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {
@@ -9500,9 +9488,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -203,9 +203,6 @@
                 "readMessages": {
                     "type": "boolean"
                 },
-                "readStatus": {
-                    "type": "boolean"
-                },
                 "rejectCall": {
                     "type": "boolean"
                 },
@@ -336,9 +333,6 @@
                 "readMessages": {
                     "type": "boolean"
                 },
-                "readStatus": {
-                    "type": "boolean"
-                },
                 "rejectCall": {
                     "type": "boolean"
                 },
@@ -390,9 +384,6 @@
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {
@@ -694,9 +685,6 @@
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {
@@ -2066,9 +2054,6 @@
                     "type": "string"
                 },
                 "readMessages": {
-                    "type": "boolean"
-                },
-                "readStatus": {
                     "type": "boolean"
                 },
                 "rejectCall": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -137,8 +137,6 @@ definitions:
         type: string
       readMessages:
         type: boolean
-      readStatus:
-        type: boolean
       rejectCall:
         type: boolean
       remoteJID:
@@ -227,8 +225,6 @@ definitions:
         type: string
       readMessages:
         type: boolean
-      readStatus:
-        type: boolean
       rejectCall:
         type: boolean
       remoteJID:
@@ -263,8 +259,6 @@ definitions:
       proxyUsername:
         type: string
       readMessages:
-        type: boolean
-      readStatus:
         type: boolean
       rejectCall:
         type: boolean
@@ -469,8 +463,6 @@ definitions:
       proxyUsername:
         type: string
       readMessages:
-        type: boolean
-      readStatus:
         type: boolean
       rejectCall:
         type: boolean
@@ -1391,8 +1383,6 @@ definitions:
       proxyUsername:
         type: string
       readMessages:
-        type: boolean
-      readStatus:
         type: boolean
       rejectCall:
         type: boolean

--- a/models/instance.go
+++ b/models/instance.go
@@ -7,7 +7,6 @@ type Instance struct {
 	GroupsIgnore      *bool           `json:"groupsIgnore,omitempty"`
 	AlwaysOnline      bool            `json:"alwaysOnline,omitempty"`
 	ReadMessages      *bool           `json:"readMessages,omitempty"`
-	ReadStatus        bool            `json:"readStatus,omitempty"`
 	SyncFullHistory   bool            `json:"syncFullHistory,omitempty"`
 	SaveMedia         *bool           `json:"saveMedia,omitempty"`
 	RemoteJID         string          `json:"remoteJID,omitempty"`


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
  - Remove the `readStatus` field from the `Instance` model;
  - Clean up the field from the generated swagger docs.
                                                                                                                                                                                                                                                                                                                                                                                 
## Checklist

- [x] Code follows project standards
- [x] Documentation updated (if applicable)
- [x] Tests executed successfully   