### PR TITLE
feat: add sync-messages route for on-demand chat history sync

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -406,6 +406,85 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/chat/syncMessages/{instance}": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Sync chat messages on demand",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sync parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SyncChatMessagesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Messages synced from the chat",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.WookMessageData"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/chat/updateMessage/{instance}": {
             "post": {
                 "security": [
@@ -3368,6 +3447,85 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/instance/{instance}/chat/syncMessages": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Sync chat messages on demand",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "instance",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sync parameters",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SyncChatMessagesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Messages synced from the chat",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.WookMessageData"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/utils.HTTPErrorResponse"
                         }
@@ -9405,6 +9563,32 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.SyncChatMessagesRequest": {
+            "type": "object",
+            "required": [
+                "id",
+                "number"
+            ],
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 1
+                },
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "since": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdateInstanceRequest": {
             "type": "object",
             "properties": {
@@ -9427,7 +9611,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "readMessages": {
-                  "type": "boolean"
+                    "type": "boolean"
                 },
                 "rejectCall": {
                     "type": "boolean"
@@ -9629,6 +9813,53 @@ const docTemplate = `{
                 }
             }
         },
+        "whatsmiau.ContactMessageRaw": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "vcard": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.ContactsArrayMessageRaw": {
+            "type": "object",
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.ContactMessageRaw"
+                    }
+                },
+                "displayName": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.ContextInfoDisappearingMode": {
+            "type": "object",
+            "properties": {
+                "initiatedByMe": {
+                    "type": "boolean"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.FileContextInfo": {
+            "type": "object",
+            "properties": {
+                "disappearingMode": {
+                    "$ref": "#/definitions/whatsmiau.ContextInfoDisappearingMode"
+                }
+            }
+        },
         "whatsmiau.FindParticipantsResponse": {
             "type": "object",
             "properties": {
@@ -9750,6 +9981,20 @@ const docTemplate = `{
                 }
             }
         },
+        "whatsmiau.ReactionMessageRaw": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "senderTimestampMs": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
         "whatsmiau.RequestParticipantResponse": {
             "type": "object",
             "properties": {
@@ -9825,6 +10070,722 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
                     }
+                }
+            }
+        },
+        "whatsmiau.WookAudioMessageRaw": {
+            "type": "object",
+            "properties": {
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.FileContextInfo"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "ptt": {
+                    "type": "boolean"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "viewOnce": {
+                    "type": "boolean"
+                },
+                "waveform": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookDocumentMessageRaw": {
+            "type": "object",
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "contactVcard": {
+                    "type": "boolean"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileName": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "pageCount": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookEncCommentMessageRaw": {
+            "type": "object",
+            "properties": {
+                "encIv": {
+                    "type": "string"
+                },
+                "encPayload": {
+                    "type": "string"
+                },
+                "targetMessageKey": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                }
+            }
+        },
+        "whatsmiau.WookImageMessageRaw": {
+            "type": "object",
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.FileContextInfo"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "viewOnce": {
+                    "type": "boolean"
+                },
+                "width": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.WookKey": {
+            "type": "object",
+            "properties": {
+                "addressingMode": {
+                    "type": "string"
+                },
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
+                    "type": "string"
+                },
+                "remoteLid": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListMessageRaw": {
+            "type": "object",
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfo"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "listType": {
+                    "type": "string"
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListSection"
+                    }
+                },
+                "singleSelectReply": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListSingleSelectReply"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListMessageRawListContextInfo": {
+            "type": "object",
+            "properties": {
+                "participant": {
+                    "type": "string"
+                },
+                "quotedMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfoMessage"
+                },
+                "stanzaId": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListMessageRawListContextInfoMessage": {
+            "type": "object",
+            "properties": {
+                "listMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfoMessageList"
+                }
+            }
+        },
+        "whatsmiau.WookListMessageRawListContextInfoMessageList": {
+            "type": "object",
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "listType": {
+                    "type": "string"
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListSection"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListMessageRawListSingleSelectReply": {
+            "type": "object",
+            "properties": {
+                "selectedRowId": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListRow": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "rowId": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookListSection": {
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListRow"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookLiveLocationMessageRaw": {
+            "type": "object",
+            "properties": {
+                "accuracyInMeters": {
+                    "type": "integer"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "degreesClockwiseFromMagneticNorth": {
+                    "type": "integer"
+                },
+                "degreesLatitude": {
+                    "type": "number"
+                },
+                "degreesLongitude": {
+                    "type": "number"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "sequenceNumber": {
+                    "type": "integer"
+                },
+                "speedInMps": {
+                    "type": "number"
+                },
+                "timeOffset": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.WookLocationMessageRaw": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "degreesLatitude": {
+                    "type": "number"
+                },
+                "degreesLongitude": {
+                    "type": "number"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookMessageContextInfo": {
+            "type": "object",
+            "properties": {
+                "conversionData": {
+                    "type": "string"
+                },
+                "conversionDelaySeconds": {
+                    "type": "integer"
+                },
+                "conversionSource": {
+                    "type": "string"
+                },
+                "disappearingMode": {
+                    "$ref": "#/definitions/whatsmiau.ContextInfoDisappearingMode"
+                },
+                "entryPointConversionApp": {
+                    "type": "string"
+                },
+                "entryPointConversionDelaySeconds": {
+                    "type": "integer"
+                },
+                "entryPointConversionSource": {
+                    "type": "string"
+                },
+                "ephemeralSettingTimestamp": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "integer"
+                },
+                "externalAdReply": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageContextInfoExternalAdReply"
+                },
+                "mentionedJid": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "quotedMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageRaw"
+                },
+                "stanzaId": {
+                    "type": "string"
+                },
+                "trustBannerAction": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.WookMessageContextInfoExternalAdReply": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "containsAutoReply": {
+                    "type": "boolean"
+                },
+                "ctwaClid": {
+                    "type": "string"
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "renderLargerThumbnail": {
+                    "type": "boolean"
+                },
+                "showAdAttribution": {
+                    "type": "boolean"
+                },
+                "sourceId": {
+                    "type": "string"
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "sourceUrl": {
+                    "type": "string"
+                },
+                "thumbnail": {
+                    "type": "string"
+                },
+                "thumbnailUrl": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookMessageData": {
+            "type": "object",
+            "properties": {
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageContextInfo"
+                },
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "message": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageRaw"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "pollUpdates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookPollUpdate"
+                    }
+                },
+                "pushName": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookMessageRaw": {
+            "type": "object",
+            "properties": {
+                "audioMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookAudioMessageRaw"
+                },
+                "base64": {
+                    "type": "string"
+                },
+                "contactMessage": {
+                    "$ref": "#/definitions/whatsmiau.ContactMessageRaw"
+                },
+                "contactsArrayMessage": {
+                    "$ref": "#/definitions/whatsmiau.ContactsArrayMessageRaw"
+                },
+                "conversation": {
+                    "type": "string"
+                },
+                "documentMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookDocumentMessageRaw"
+                },
+                "encCommentMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookEncCommentMessageRaw"
+                },
+                "imageMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookImageMessageRaw"
+                },
+                "listResponseMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRaw"
+                },
+                "liveLocationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookLiveLocationMessageRaw"
+                },
+                "locationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookLocationMessageRaw"
+                },
+                "mediaUrl": {
+                    "description": "Sent when connect with some storage",
+                    "type": "string"
+                },
+                "pollCreationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPollCreationMessageRaw"
+                },
+                "pollUpdateMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPollUpdateMessageRaw"
+                },
+                "ptvMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPtvMessageRaw"
+                },
+                "reactionMessage": {
+                    "$ref": "#/definitions/whatsmiau.ReactionMessageRaw"
+                },
+                "stickerMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookStickerMessageRaw"
+                },
+                "videoMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookVideoMessageRaw"
+                }
+            }
+        },
+        "whatsmiau.WookPollCreationMessageRaw": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookPollOption"
+                    }
+                },
+                "selectableOptionsCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.WookPollOption": {
+            "type": "object",
+            "properties": {
+                "optionName": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookPollUpdate": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "voters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "whatsmiau.WookPollUpdateMessageRaw": {
+            "type": "object",
+            "properties": {
+                "pollCreationMessageKey": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "senderTimestampMs": {
+                    "type": "string"
+                },
+                "vote": {
+                    "$ref": "#/definitions/whatsmiau.WookPollVote"
+                }
+            }
+        },
+        "whatsmiau.WookPollVote": {
+            "type": "object",
+            "properties": {
+                "encIv": {
+                    "type": "string"
+                },
+                "encPayload": {
+                    "type": "string"
+                },
+                "selectedOptions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "whatsmiau.WookPtvMessageRaw": {
+            "type": "object",
+            "properties": {
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "whatsmiau.WookStickerMessageRaw": {
+            "type": "object",
+            "properties": {
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "isAnimated": {
+                    "type": "boolean"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "pngThumbnail": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "integer"
+                }
+            }
+        },
+        "whatsmiau.WookVideoMessageRaw": {
+            "type": "object",
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "gifPlayback": {
+                    "type": "boolean"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -413,7 +413,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The primary device (phone) must have a server-connected WhatsApp session — history is served from its local message store. The ` + "`" + `id` + "`" + ` anchor is required: history is returned backwards from it, ` + "`" + `count` + "`" + ` messages per page (default 50). Optionally paginates back to a target date with ` + "`" + `since` + "`" + `. A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3461,7 +3461,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The primary device (phone) must have a server-connected WhatsApp session — history is served from its local message store. The ` + "`" + `id` + "`" + ` anchor is required: history is returned backwards from it, ` + "`" + `count` + "`" + ` messages per page (default 50). Optionally paginates back to a target date with ` + "`" + `since` + "`" + `. A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3636,7 +3636,7 @@
                 "consumes": [
                     "application/json"
                 ],
-                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The primary device (phone) must have a server-connected WhatsApp session — history is served from its local message store. The `id` anchor is required: history is returned backwards from it, `count` messages per page (default 50). Optionally paginates back to a target date with `since`. A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
                 "operationId": "postV1ChatSyncMessagesByInstance",
                 "parameters": [
                     {
@@ -6963,7 +6963,7 @@
                 "consumes": [
                     "application/json"
                 ],
-                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The primary device (phone) must have a server-connected WhatsApp session — history is served from its local message store. The `id` anchor is required: history is returned backwards from it, `count` messages per page (default 50). Optionally paginates back to a target date with `since`. A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
                 "operationId": "postV1InstanceByInstanceChatSyncMessages",
                 "parameters": [
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1972,6 +1972,32 @@
             },
             "type": "object"
         },
+        "dto.SyncChatMessagesRequest": {
+            "properties": {
+                "count": {
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "string"
+                },
+                "since": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "number"
+            ],
+            "type": "object"
+        },
         "dto.UpdateInstanceRequest": {
             "properties": {
                 "groupsIgnore": {
@@ -1993,7 +2019,7 @@
                     "type": "string"
                 },
                 "readMessages": {
-                  "type": "boolean"
+                    "type": "boolean"
                 },
                 "rejectCall": {
                     "type": "boolean"
@@ -2196,6 +2222,53 @@
             },
             "type": "object"
         },
+        "whatsmiau.ContactMessageRaw": {
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "vcard": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.ContactsArrayMessageRaw": {
+            "properties": {
+                "contacts": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.ContactMessageRaw"
+                    },
+                    "type": "array"
+                },
+                "displayName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.ContextInfoDisappearingMode": {
+            "properties": {
+                "initiatedByMe": {
+                    "type": "boolean"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.FileContextInfo": {
+            "properties": {
+                "disappearingMode": {
+                    "$ref": "#/definitions/whatsmiau.ContextInfoDisappearingMode"
+                }
+            },
+            "type": "object"
+        },
         "whatsmiau.FindParticipantsResponse": {
             "properties": {
                 "participants": {
@@ -2317,6 +2390,20 @@
             },
             "type": "object"
         },
+        "whatsmiau.ReactionMessageRaw": {
+            "properties": {
+                "key": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "senderTimestampMs": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "whatsmiau.RequestParticipantResponse": {
             "properties": {
                 "jid": {
@@ -2391,6 +2478,722 @@
                         "$ref": "#/definitions/whatsmiau.GroupParticipantResponse"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookAudioMessageRaw": {
+            "properties": {
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.FileContextInfo"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "ptt": {
+                    "type": "boolean"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "viewOnce": {
+                    "type": "boolean"
+                },
+                "waveform": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookDocumentMessageRaw": {
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "contactVcard": {
+                    "type": "boolean"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileName": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "pageCount": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookEncCommentMessageRaw": {
+            "properties": {
+                "encIv": {
+                    "type": "string"
+                },
+                "encPayload": {
+                    "type": "string"
+                },
+                "targetMessageKey": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookImageMessageRaw": {
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.FileContextInfo"
+                },
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "viewOnce": {
+                    "type": "boolean"
+                },
+                "width": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookKey": {
+            "properties": {
+                "addressingMode": {
+                    "type": "string"
+                },
+                "fromMe": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "remoteJid": {
+                    "type": "string"
+                },
+                "remoteLid": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListMessageRaw": {
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfo"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "listType": {
+                    "type": "string"
+                },
+                "sections": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListSection"
+                    },
+                    "type": "array"
+                },
+                "singleSelectReply": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListSingleSelectReply"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListMessageRawListContextInfo": {
+            "properties": {
+                "participant": {
+                    "type": "string"
+                },
+                "quotedMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfoMessage"
+                },
+                "stanzaId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListMessageRawListContextInfoMessage": {
+            "properties": {
+                "listMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRawListContextInfoMessageList"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListMessageRawListContextInfoMessageList": {
+            "properties": {
+                "buttonText": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "footerText": {
+                    "type": "string"
+                },
+                "listType": {
+                    "type": "string"
+                },
+                "sections": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListSection"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListMessageRawListSingleSelectReply": {
+            "properties": {
+                "selectedRowId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListRow": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "rowId": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookListSection": {
+            "properties": {
+                "rows": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookListRow"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookLiveLocationMessageRaw": {
+            "properties": {
+                "accuracyInMeters": {
+                    "type": "integer"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "degreesClockwiseFromMagneticNorth": {
+                    "type": "integer"
+                },
+                "degreesLatitude": {
+                    "type": "number"
+                },
+                "degreesLongitude": {
+                    "type": "number"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "sequenceNumber": {
+                    "type": "integer"
+                },
+                "speedInMps": {
+                    "type": "number"
+                },
+                "timeOffset": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookLocationMessageRaw": {
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "degreesLatitude": {
+                    "type": "number"
+                },
+                "degreesLongitude": {
+                    "type": "number"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookMessageContextInfo": {
+            "properties": {
+                "conversionData": {
+                    "type": "string"
+                },
+                "conversionDelaySeconds": {
+                    "type": "integer"
+                },
+                "conversionSource": {
+                    "type": "string"
+                },
+                "disappearingMode": {
+                    "$ref": "#/definitions/whatsmiau.ContextInfoDisappearingMode"
+                },
+                "entryPointConversionApp": {
+                    "type": "string"
+                },
+                "entryPointConversionDelaySeconds": {
+                    "type": "integer"
+                },
+                "entryPointConversionSource": {
+                    "type": "string"
+                },
+                "ephemeralSettingTimestamp": {
+                    "type": "string"
+                },
+                "expiration": {
+                    "type": "integer"
+                },
+                "externalAdReply": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageContextInfoExternalAdReply"
+                },
+                "mentionedJid": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "participant": {
+                    "type": "string"
+                },
+                "quotedMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageRaw"
+                },
+                "stanzaId": {
+                    "type": "string"
+                },
+                "trustBannerAction": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookMessageContextInfoExternalAdReply": {
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "containsAutoReply": {
+                    "type": "boolean"
+                },
+                "ctwaClid": {
+                    "type": "string"
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "renderLargerThumbnail": {
+                    "type": "boolean"
+                },
+                "showAdAttribution": {
+                    "type": "boolean"
+                },
+                "sourceId": {
+                    "type": "string"
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "sourceUrl": {
+                    "type": "string"
+                },
+                "thumbnail": {
+                    "type": "string"
+                },
+                "thumbnailUrl": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookMessageData": {
+            "properties": {
+                "contextInfo": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageContextInfo"
+                },
+                "instanceId": {
+                    "type": "string"
+                },
+                "key": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "message": {
+                    "$ref": "#/definitions/whatsmiau.WookMessageRaw"
+                },
+                "messageTimestamp": {
+                    "type": "integer"
+                },
+                "messageType": {
+                    "type": "string"
+                },
+                "pollUpdates": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookPollUpdate"
+                    },
+                    "type": "array"
+                },
+                "pushName": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookMessageRaw": {
+            "properties": {
+                "audioMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookAudioMessageRaw"
+                },
+                "base64": {
+                    "type": "string"
+                },
+                "contactMessage": {
+                    "$ref": "#/definitions/whatsmiau.ContactMessageRaw"
+                },
+                "contactsArrayMessage": {
+                    "$ref": "#/definitions/whatsmiau.ContactsArrayMessageRaw"
+                },
+                "conversation": {
+                    "type": "string"
+                },
+                "documentMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookDocumentMessageRaw"
+                },
+                "encCommentMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookEncCommentMessageRaw"
+                },
+                "imageMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookImageMessageRaw"
+                },
+                "listResponseMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookListMessageRaw"
+                },
+                "liveLocationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookLiveLocationMessageRaw"
+                },
+                "locationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookLocationMessageRaw"
+                },
+                "mediaUrl": {
+                    "description": "Sent when connect with some storage",
+                    "type": "string"
+                },
+                "pollCreationMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPollCreationMessageRaw"
+                },
+                "pollUpdateMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPollUpdateMessageRaw"
+                },
+                "ptvMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookPtvMessageRaw"
+                },
+                "reactionMessage": {
+                    "$ref": "#/definitions/whatsmiau.ReactionMessageRaw"
+                },
+                "stickerMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookStickerMessageRaw"
+                },
+                "videoMessage": {
+                    "$ref": "#/definitions/whatsmiau.WookVideoMessageRaw"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPollCreationMessageRaw": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "options": {
+                    "items": {
+                        "$ref": "#/definitions/whatsmiau.WookPollOption"
+                    },
+                    "type": "array"
+                },
+                "selectableOptionsCount": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPollOption": {
+            "properties": {
+                "optionName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPollUpdate": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "voters": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPollUpdateMessageRaw": {
+            "properties": {
+                "pollCreationMessageKey": {
+                    "$ref": "#/definitions/whatsmiau.WookKey"
+                },
+                "senderTimestampMs": {
+                    "type": "string"
+                },
+                "vote": {
+                    "$ref": "#/definitions/whatsmiau.WookPollVote"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPollVote": {
+            "properties": {
+                "encIv": {
+                    "type": "string"
+                },
+                "encPayload": {
+                    "type": "string"
+                },
+                "selectedOptions": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookPtvMessageRaw": {
+            "properties": {
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookStickerMessageRaw": {
+            "properties": {
+                "directPath": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "isAnimated": {
+                    "type": "boolean"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mediaKeyTimestamp": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "pngThumbnail": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "whatsmiau.WookVideoMessageRaw": {
+            "properties": {
+                "caption": {
+                    "type": "string"
+                },
+                "fileEncSha256": {
+                    "type": "string"
+                },
+                "fileLength": {
+                    "type": "string"
+                },
+                "fileSha256": {
+                    "type": "string"
+                },
+                "gifPlayback": {
+                    "type": "boolean"
+                },
+                "jpegThumbnail": {
+                    "type": "string"
+                },
+                "mediaKey": {
+                    "type": "string"
+                },
+                "mimetype": {
+                    "type": "string"
+                },
+                "seconds": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -2823,6 +3626,92 @@
                     }
                 ],
                 "summary": "Send chat presence (typing indicator)",
+                "tags": [
+                    "Chat"
+                ]
+            }
+        },
+        "/v1/chat/syncMessages/{instance}": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "operationId": "postV1ChatSyncMessagesByInstance",
+                "parameters": [
+                    {
+                        "description": "Instance ID",
+                        "in": "path",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "Sync parameters",
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SyncChatMessagesRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Messages synced from the chat",
+                        "schema": {
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.WookMessageData"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.AuthenticationErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Sync chat messages on demand",
                 "tags": [
                     "Chat"
                 ]
@@ -6064,6 +6953,92 @@
                     }
                 ],
                 "summary": "Mark messages as read",
+                "tags": [
+                    "Chat"
+                ]
+            }
+        },
+        "/v1/instance/{instance}/chat/syncMessages": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "description": "Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.",
+                "operationId": "postV1InstanceByInstanceChatSyncMessages",
+                "parameters": [
+                    {
+                        "description": "Instance ID",
+                        "in": "path",
+                        "name": "instance",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "Sync parameters",
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.SyncChatMessagesRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Messages synced from the chat",
+                        "schema": {
+                            "items": {
+                                "$ref": "#/definitions/whatsmiau.WookMessageData"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.AuthenticationErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/utils.HTTPErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Sync chat messages on demand",
                 "tags": [
                     "Chat"
                 ]

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1328,6 +1328,24 @@ definitions:
       state:
         type: string
     type: object
+  dto.SyncChatMessagesRequest:
+    properties:
+      count:
+        maximum: 100
+        minimum: 1
+        type: integer
+      fromMe:
+        type: boolean
+      id:
+        type: string
+      number:
+        type: string
+      since:
+        type: string
+    required:
+    - id
+    - number
+    type: object
   dto.UpdateInstanceRequest:
     properties:
       groupsIgnore:
@@ -1478,6 +1496,36 @@ definitions:
       groupJid:
         type: string
     type: object
+  whatsmiau.ContactMessageRaw:
+    properties:
+      displayName:
+        type: string
+      vcard:
+        type: string
+    type: object
+  whatsmiau.ContactsArrayMessageRaw:
+    properties:
+      contacts:
+        items:
+          $ref: '#/definitions/whatsmiau.ContactMessageRaw'
+        type: array
+      displayName:
+        type: string
+    type: object
+  whatsmiau.ContextInfoDisappearingMode:
+    properties:
+      initiatedByMe:
+        type: boolean
+      initiator:
+        type: string
+      trigger:
+        type: string
+    type: object
+  whatsmiau.FileContextInfo:
+    properties:
+      disappearingMode:
+        $ref: '#/definitions/whatsmiau.ContextInfoDisappearingMode'
+    type: object
   whatsmiau.FindParticipantsResponse:
     properties:
       participants:
@@ -1557,6 +1605,15 @@ definitions:
       lid:
         type: string
     type: object
+  whatsmiau.ReactionMessageRaw:
+    properties:
+      key:
+        $ref: '#/definitions/whatsmiau.WookKey'
+      senderTimestampMs:
+        type: string
+      text:
+        type: string
+    type: object
   whatsmiau.RequestParticipantResponse:
     properties:
       jid:
@@ -1606,6 +1663,475 @@ definitions:
         items:
           $ref: '#/definitions/whatsmiau.GroupParticipantResponse'
         type: array
+    type: object
+  whatsmiau.WookAudioMessageRaw:
+    properties:
+      contextInfo:
+        $ref: '#/definitions/whatsmiau.FileContextInfo'
+      directPath:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileSha256:
+        type: string
+      mediaKey:
+        type: string
+      mediaKeyTimestamp:
+        type: string
+      mimetype:
+        type: string
+      ptt:
+        type: boolean
+      seconds:
+        type: integer
+      url:
+        type: string
+      viewOnce:
+        type: boolean
+      waveform:
+        type: string
+    type: object
+  whatsmiau.WookDocumentMessageRaw:
+    properties:
+      caption:
+        type: string
+      contactVcard:
+        type: boolean
+      directPath:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileName:
+        type: string
+      fileSha256:
+        type: string
+      jpegThumbnail:
+        type: string
+      mediaKey:
+        type: string
+      mediaKeyTimestamp:
+        type: string
+      mimetype:
+        type: string
+      pageCount:
+        type: integer
+      title:
+        type: string
+      url:
+        type: string
+    type: object
+  whatsmiau.WookEncCommentMessageRaw:
+    properties:
+      encIv:
+        type: string
+      encPayload:
+        type: string
+      targetMessageKey:
+        $ref: '#/definitions/whatsmiau.WookKey'
+    type: object
+  whatsmiau.WookImageMessageRaw:
+    properties:
+      caption:
+        type: string
+      contextInfo:
+        $ref: '#/definitions/whatsmiau.FileContextInfo'
+      directPath:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileSha256:
+        type: string
+      height:
+        type: integer
+      jpegThumbnail:
+        type: string
+      mediaKey:
+        type: string
+      mediaKeyTimestamp:
+        type: string
+      mimetype:
+        type: string
+      url:
+        type: string
+      viewOnce:
+        type: boolean
+      width:
+        type: integer
+    type: object
+  whatsmiau.WookKey:
+    properties:
+      addressingMode:
+        type: string
+      fromMe:
+        type: boolean
+      id:
+        type: string
+      participant:
+        type: string
+      remoteJid:
+        type: string
+      remoteLid:
+        type: string
+    type: object
+  whatsmiau.WookListMessageRaw:
+    properties:
+      buttonText:
+        type: string
+      contextInfo:
+        $ref: '#/definitions/whatsmiau.WookListMessageRawListContextInfo'
+      description:
+        type: string
+      footerText:
+        type: string
+      listType:
+        type: string
+      sections:
+        items:
+          $ref: '#/definitions/whatsmiau.WookListSection'
+        type: array
+      singleSelectReply:
+        $ref: '#/definitions/whatsmiau.WookListMessageRawListSingleSelectReply'
+      title:
+        type: string
+    type: object
+  whatsmiau.WookListMessageRawListContextInfo:
+    properties:
+      participant:
+        type: string
+      quotedMessage:
+        $ref: '#/definitions/whatsmiau.WookListMessageRawListContextInfoMessage'
+      stanzaId:
+        type: string
+    type: object
+  whatsmiau.WookListMessageRawListContextInfoMessage:
+    properties:
+      listMessage:
+        $ref: '#/definitions/whatsmiau.WookListMessageRawListContextInfoMessageList'
+    type: object
+  whatsmiau.WookListMessageRawListContextInfoMessageList:
+    properties:
+      buttonText:
+        type: string
+      description:
+        type: string
+      footerText:
+        type: string
+      listType:
+        type: string
+      sections:
+        items:
+          $ref: '#/definitions/whatsmiau.WookListSection'
+        type: array
+      title:
+        type: string
+    type: object
+  whatsmiau.WookListMessageRawListSingleSelectReply:
+    properties:
+      selectedRowId:
+        type: string
+    type: object
+  whatsmiau.WookListRow:
+    properties:
+      description:
+        type: string
+      rowId:
+        type: string
+      title:
+        type: string
+    type: object
+  whatsmiau.WookListSection:
+    properties:
+      rows:
+        items:
+          $ref: '#/definitions/whatsmiau.WookListRow'
+        type: array
+      title:
+        type: string
+    type: object
+  whatsmiau.WookLiveLocationMessageRaw:
+    properties:
+      accuracyInMeters:
+        type: integer
+      caption:
+        type: string
+      degreesClockwiseFromMagneticNorth:
+        type: integer
+      degreesLatitude:
+        type: number
+      degreesLongitude:
+        type: number
+      jpegThumbnail:
+        type: string
+      sequenceNumber:
+        type: integer
+      speedInMps:
+        type: number
+      timeOffset:
+        type: integer
+    type: object
+  whatsmiau.WookLocationMessageRaw:
+    properties:
+      address:
+        type: string
+      degreesLatitude:
+        type: number
+      degreesLongitude:
+        type: number
+      jpegThumbnail:
+        type: string
+      name:
+        type: string
+      url:
+        type: string
+    type: object
+  whatsmiau.WookMessageContextInfo:
+    properties:
+      conversionData:
+        type: string
+      conversionDelaySeconds:
+        type: integer
+      conversionSource:
+        type: string
+      disappearingMode:
+        $ref: '#/definitions/whatsmiau.ContextInfoDisappearingMode'
+      entryPointConversionApp:
+        type: string
+      entryPointConversionDelaySeconds:
+        type: integer
+      entryPointConversionSource:
+        type: string
+      ephemeralSettingTimestamp:
+        type: string
+      expiration:
+        type: integer
+      externalAdReply:
+        $ref: '#/definitions/whatsmiau.WookMessageContextInfoExternalAdReply'
+      mentionedJid:
+        items:
+          type: string
+        type: array
+      participant:
+        type: string
+      quotedMessage:
+        $ref: '#/definitions/whatsmiau.WookMessageRaw'
+      stanzaId:
+        type: string
+      trustBannerAction:
+        type: integer
+    type: object
+  whatsmiau.WookMessageContextInfoExternalAdReply:
+    properties:
+      body:
+        type: string
+      containsAutoReply:
+        type: boolean
+      ctwaClid:
+        type: string
+      mediaType:
+        type: string
+      renderLargerThumbnail:
+        type: boolean
+      showAdAttribution:
+        type: boolean
+      sourceId:
+        type: string
+      sourceType:
+        type: string
+      sourceUrl:
+        type: string
+      thumbnail:
+        type: string
+      thumbnailUrl:
+        type: string
+      title:
+        type: string
+    type: object
+  whatsmiau.WookMessageData:
+    properties:
+      contextInfo:
+        $ref: '#/definitions/whatsmiau.WookMessageContextInfo'
+      instanceId:
+        type: string
+      key:
+        $ref: '#/definitions/whatsmiau.WookKey'
+      message:
+        $ref: '#/definitions/whatsmiau.WookMessageRaw'
+      messageTimestamp:
+        type: integer
+      messageType:
+        type: string
+      pollUpdates:
+        items:
+          $ref: '#/definitions/whatsmiau.WookPollUpdate'
+        type: array
+      pushName:
+        type: string
+      source:
+        type: string
+      status:
+        type: string
+    type: object
+  whatsmiau.WookMessageRaw:
+    properties:
+      audioMessage:
+        $ref: '#/definitions/whatsmiau.WookAudioMessageRaw'
+      base64:
+        type: string
+      contactMessage:
+        $ref: '#/definitions/whatsmiau.ContactMessageRaw'
+      contactsArrayMessage:
+        $ref: '#/definitions/whatsmiau.ContactsArrayMessageRaw'
+      conversation:
+        type: string
+      documentMessage:
+        $ref: '#/definitions/whatsmiau.WookDocumentMessageRaw'
+      encCommentMessage:
+        $ref: '#/definitions/whatsmiau.WookEncCommentMessageRaw'
+      imageMessage:
+        $ref: '#/definitions/whatsmiau.WookImageMessageRaw'
+      listResponseMessage:
+        $ref: '#/definitions/whatsmiau.WookListMessageRaw'
+      liveLocationMessage:
+        $ref: '#/definitions/whatsmiau.WookLiveLocationMessageRaw'
+      locationMessage:
+        $ref: '#/definitions/whatsmiau.WookLocationMessageRaw'
+      mediaUrl:
+        description: Sent when connect with some storage
+        type: string
+      pollCreationMessage:
+        $ref: '#/definitions/whatsmiau.WookPollCreationMessageRaw'
+      pollUpdateMessage:
+        $ref: '#/definitions/whatsmiau.WookPollUpdateMessageRaw'
+      ptvMessage:
+        $ref: '#/definitions/whatsmiau.WookPtvMessageRaw'
+      reactionMessage:
+        $ref: '#/definitions/whatsmiau.ReactionMessageRaw'
+      stickerMessage:
+        $ref: '#/definitions/whatsmiau.WookStickerMessageRaw'
+      videoMessage:
+        $ref: '#/definitions/whatsmiau.WookVideoMessageRaw'
+    type: object
+  whatsmiau.WookPollCreationMessageRaw:
+    properties:
+      name:
+        type: string
+      options:
+        items:
+          $ref: '#/definitions/whatsmiau.WookPollOption'
+        type: array
+      selectableOptionsCount:
+        type: integer
+    type: object
+  whatsmiau.WookPollOption:
+    properties:
+      optionName:
+        type: string
+    type: object
+  whatsmiau.WookPollUpdate:
+    properties:
+      name:
+        type: string
+      voters:
+        items:
+          type: string
+        type: array
+    type: object
+  whatsmiau.WookPollUpdateMessageRaw:
+    properties:
+      pollCreationMessageKey:
+        $ref: '#/definitions/whatsmiau.WookKey'
+      senderTimestampMs:
+        type: string
+      vote:
+        $ref: '#/definitions/whatsmiau.WookPollVote'
+    type: object
+  whatsmiau.WookPollVote:
+    properties:
+      encIv:
+        type: string
+      encPayload:
+        type: string
+      selectedOptions:
+        items:
+          type: string
+        type: array
+    type: object
+  whatsmiau.WookPtvMessageRaw:
+    properties:
+      directPath:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileSha256:
+        type: string
+      jpegThumbnail:
+        type: string
+      mediaKey:
+        type: string
+      mimetype:
+        type: string
+      seconds:
+        type: integer
+      url:
+        type: string
+    type: object
+  whatsmiau.WookStickerMessageRaw:
+    properties:
+      directPath:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileSha256:
+        type: string
+      height:
+        type: integer
+      isAnimated:
+        type: boolean
+      mediaKey:
+        type: string
+      mediaKeyTimestamp:
+        type: string
+      mimetype:
+        type: string
+      pngThumbnail:
+        type: string
+      url:
+        type: string
+      width:
+        type: integer
+    type: object
+  whatsmiau.WookVideoMessageRaw:
+    properties:
+      caption:
+        type: string
+      fileEncSha256:
+        type: string
+      fileLength:
+        type: string
+      fileSha256:
+        type: string
+      gifPlayback:
+        type: boolean
+      jpegThumbnail:
+        type: string
+      mediaKey:
+        type: string
+      mimetype:
+        type: string
+      seconds:
+        type: integer
+      url:
+        type: string
     type: object
 host: localhost:8080
 info:
@@ -1898,6 +2424,66 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Send chat presence (typing indicator)
+      tags:
+      - Chat
+  /v1/chat/syncMessages/{instance}:
+    post:
+      consumes:
+      - application/json
+      description: Requests message history for a chat from the user's primary device
+        (on-demand history sync). The phone must be online. Optionally filters by
+        date (since). History is returned backwards from the anchor (or the most recent
+        messages when no anchor is provided). A single request returns at most 500
+        messages. Recommended not to be used for bulk history extraction.
+      operationId: postV1ChatSyncMessagesByInstance
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Sync parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SyncChatMessagesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Messages synced from the chat
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.WookMessageData'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.AuthenticationErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Sync chat messages on demand
       tags:
       - Chat
   /v1/chat/updateMessage/{instance}:
@@ -3650,6 +4236,66 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Mark messages as read
+      tags:
+      - Chat
+  /v1/instance/{instance}/chat/syncMessages:
+    post:
+      consumes:
+      - application/json
+      description: Requests message history for a chat from the user's primary device
+        (on-demand history sync). The phone must be online. Optionally filters by
+        date (since). History is returned backwards from the anchor (or the most recent
+        messages when no anchor is provided). A single request returns at most 500
+        messages. Recommended not to be used for bulk history extraction.
+      operationId: postV1InstanceByInstanceChatSyncMessages
+      parameters:
+      - description: Instance ID
+        in: path
+        name: instance
+        required: true
+        type: string
+      - description: Sync parameters
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SyncChatMessagesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Messages synced from the chat
+          schema:
+            items:
+              $ref: '#/definitions/whatsmiau.WookMessageData'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.AuthenticationErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/utils.HTTPErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Sync chat messages on demand
       tags:
       - Chat
   /v1/instance/{instance}/community/create:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2430,11 +2430,13 @@ paths:
     post:
       consumes:
       - application/json
-      description: Requests message history for a chat from the user's primary device
-        (on-demand history sync). The phone must be online. Optionally filters by
-        date (since). History is returned backwards from the anchor (or the most recent
-        messages when no anchor is provided). A single request returns at most 500
-        messages. Recommended not to be used for bulk history extraction.
+      description: 'Requests message history for a chat from the user''s primary device
+        (on-demand history sync). The primary device (phone) must have a server-connected
+        WhatsApp session — history is served from its local message store. The `id`
+        anchor is required: history is returned backwards from it, `count` messages
+        per page (default 50). Optionally paginates back to a target date with `since`.
+        A single request returns at most 500 messages. Recommended not to be used
+        for bulk history extraction.'
       operationId: postV1ChatSyncMessagesByInstance
       parameters:
       - description: Instance ID
@@ -4242,11 +4244,13 @@ paths:
     post:
       consumes:
       - application/json
-      description: Requests message history for a chat from the user's primary device
-        (on-demand history sync). The phone must be online. Optionally filters by
-        date (since). History is returned backwards from the anchor (or the most recent
-        messages when no anchor is provided). A single request returns at most 500
-        messages. Recommended not to be used for bulk history extraction.
+      description: 'Requests message history for a chat from the user''s primary device
+        (on-demand history sync). The primary device (phone) must have a server-connected
+        WhatsApp session — history is served from its local message store. The `id`
+        anchor is required: history is returned backwards from it, `count` messages
+        per page (default 50). Optionally paginates back to a target date with `since`.
+        A single request returns at most 500 messages. Recommended not to be used
+        for bulk history extraction.'
       operationId: postV1InstanceByInstanceChatSyncMessages
       parameters:
       - description: Instance ID

--- a/docs/swagger_contract_test.go
+++ b/docs/swagger_contract_test.go
@@ -35,10 +35,10 @@ func TestSwaggerCoversEveryDocumentedRoute(t *testing.T) {
 	}
 
 	operations := append(routes.DocumentedV1Operations(), routes.DocumentedDocumentationOperations()...)
-	if got, want := len(routes.DocumentedV1Operations()), 104; got != want {
+	if got, want := len(routes.DocumentedV1Operations()), 106; got != want {
 		t.Fatalf("unexpected /v1 operation inventory size: got %d, want %d", got, want)
 	}
-	if got, want := len(operations), 108; got != want {
+	if got, want := len(operations), 110; got != want {
 		t.Fatalf("unexpected full operation inventory size: got %d, want %d", got, want)
 	}
 

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -219,7 +219,9 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 			}
 
 			if hs, ok := evt.(*events.HistorySync); ok && hs.Data != nil && hs.Data.GetSyncType() == waHistorySync.HistorySync_ON_DEMAND {
-				if w, ok := s.pendingSyncs.Load(id); ok && historySyncMatchesChat(hs, w.chat) {
+				if w, ok := s.pendingSyncs.Load(id); ok &&
+					historySyncMatchesChat(hs, w.chat) &&
+					historySyncMatchesSend(hs, w.sendID) {
 					// Non-blocking send: a stale duplicate blob arriving after a
 					// timeout must not stall this event goroutine.
 					select {

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -228,7 +228,6 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 					case w.ch <- hs:
 					default:
 					}
-					s.pendingSyncs.Delete(id)
 				}
 				return
 			}

--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -218,6 +218,19 @@ func (s *Whatsmiau) Handle(id string) whatsmeow.EventHandler {
 				}
 			}
 
+			if hs, ok := evt.(*events.HistorySync); ok && hs.Data != nil && hs.Data.GetSyncType() == waHistorySync.HistorySync_ON_DEMAND {
+				if w, ok := s.pendingSyncs.Load(id); ok && historySyncMatchesChat(hs, w.chat) {
+					// Non-blocking send: a stale duplicate blob arriving after a
+					// timeout must not stall this event goroutine.
+					select {
+					case w.ch <- hs:
+					default:
+					}
+					s.pendingSyncs.Delete(id)
+				}
+				return
+			}
+
 			if instance.Webhook.Enabled != nil && !*instance.Webhook.Enabled {
 				return
 			}

--- a/lib/whatsmiau/models.go
+++ b/lib/whatsmiau/models.go
@@ -128,7 +128,7 @@ type ContactsArrayMessageRaw struct {
 type ContactMessageRaw struct {
 	VCard        string     `json:"vcard,omitempty"`
 	DisplayName  string     `json:"displayName,omitempty"`
-	DecodedVcard vcard.Card `json:"decodedVcard,omitempty"`
+	DecodedVcard vcard.Card `json:"decodedVcard,omitempty" swaggerignore:"true"`
 }
 
 type WookListMessageRaw struct {

--- a/lib/whatsmiau/sync.go
+++ b/lib/whatsmiau/sync.go
@@ -23,8 +23,9 @@ const (
 var ErrSyncTimeout = errors.New("timeout: phone did not respond in time")
 
 type pendingSyncWaiter struct {
-	chat types.JID
-	ch   chan *events.HistorySync
+	chat   types.JID
+	sendID string
+	ch     chan *events.HistorySync
 }
 
 type SyncChatMessagesRequest struct {
@@ -46,6 +47,14 @@ func historySyncMatchesChat(evt *events.HistorySync, chat types.JID) bool {
 		}
 	}
 	return false
+}
+
+func historySyncMatchesSend(evt *events.HistorySync, sendID string) bool {
+	if evt == nil || evt.Notification == nil || sendID == "" {
+		return true
+	}
+	respID := evt.Notification.GetPeerDataRequestSessionID()
+	return respID == "" || respID == sendID
 }
 
 func (s *Whatsmiau) SyncChatMessages(ctx context.Context, req *SyncChatMessagesRequest) ([]WookMessageData, error) {
@@ -100,10 +109,7 @@ func (s *Whatsmiau) SyncChatMessages(ctx context.Context, req *SyncChatMessagesR
 			},
 		}
 
-		waiter := &pendingSyncWaiter{chat: chatJID, ch: make(chan *events.HistorySync, 1)}
-		s.pendingSyncs.Store(req.InstanceID, waiter)
-
-		_, err := client.SendPeerMessage(ctx, msg)
+		resp, err := client.SendPeerMessage(ctx, msg)
 		if err != nil {
 			s.pendingSyncs.Delete(req.InstanceID)
 
@@ -112,6 +118,9 @@ func (s *Whatsmiau) SyncChatMessages(ctx context.Context, req *SyncChatMessagesR
 			}
 			return nil, err
 		}
+
+		waiter := &pendingSyncWaiter{chat: chatJID, sendID: resp.ID, ch: make(chan *events.HistorySync, 1)}
+		s.pendingSyncs.Store(req.InstanceID, waiter)
 
 		// Wait for the phone to respond.
 		var evt *events.HistorySync

--- a/lib/whatsmiau/sync.go
+++ b/lib/whatsmiau/sync.go
@@ -1,0 +1,202 @@
+package whatsmiau
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// syncTimeout is how long to wait for the phone to respond per page.
+	syncTimeout = 30 * time.Second
+	syncDefaultCount = 50
+	maxSyncMessages = 500
+)
+
+var ErrSyncTimeout = errors.New("timeout: phone did not respond in time")
+
+type pendingSyncWaiter struct {
+	chat types.JID
+	ch   chan *events.HistorySync
+}
+
+type SyncChatMessagesRequest struct {
+	InstanceID string
+	Chat       types.JID
+	Count      int
+	Since      *time.Time
+	ID         string
+	FromMe     *bool
+}
+
+func historySyncMatchesChat(evt *events.HistorySync, chat types.JID) bool {
+	if evt == nil || evt.Data == nil {
+		return false
+	}
+	for _, conv := range evt.Data.GetConversations() {
+		if conv.GetID() == chat.String() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Whatsmiau) SyncChatMessages(ctx context.Context, req *SyncChatMessagesRequest) ([]WookMessageData, error) {
+	syncMu, _ := s.syncLocks.LoadOrStore(req.InstanceID, &sync.Mutex{})
+	syncMu.Lock()
+	defer syncMu.Unlock()
+
+	// Load client and check connection.
+	client, ok := s.clients.Load(req.InstanceID)
+	if !ok {
+		return nil, whatsmeow.ErrClientIsNil
+	}
+	if !client.IsConnected() {
+		return nil, errors.New("client not connected")
+	}
+
+	count := req.Count
+	if count <= 0 {
+		count = syncDefaultCount
+	}
+
+	chatJID := req.Chat
+	if chatJID.Server == types.DefaultUserServer && client.Store != nil && client.Store.LIDs != nil {
+		if lid, err := client.Store.LIDs.GetLIDForPN(ctx, chatJID); err == nil && !lid.IsEmpty() {
+			chatJID = lid
+		}
+	}
+
+	var allMessages []WookMessageData
+	anchorTS := time.Now().Unix()
+
+	for {
+		onDemand := &waE2E.PeerDataOperationRequestMessage_HistorySyncOnDemandRequest{
+			ChatJID:              proto.String(chatJID.String()),
+			OnDemandMsgCount:     proto.Int32(int32(count)),
+			OldestMsgTimestampMS: proto.Int64(anchorTS),
+		}
+		if req.ID != "" {
+			onDemand.OldestMsgID = proto.String(req.ID)
+			if req.FromMe != nil {
+				onDemand.OldestMsgFromMe = proto.Bool(*req.FromMe)
+			}
+		}
+
+		msg := &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Type: waE2E.ProtocolMessage_PEER_DATA_OPERATION_REQUEST_MESSAGE.Enum(),
+				PeerDataOperationRequestMessage: &waE2E.PeerDataOperationRequestMessage{
+					PeerDataOperationRequestType: waE2E.PeerDataOperationRequestType_HISTORY_SYNC_ON_DEMAND.Enum(),
+					HistorySyncOnDemandRequest:   onDemand,
+				},
+			},
+		}
+
+		waiter := &pendingSyncWaiter{chat: chatJID, ch: make(chan *events.HistorySync, 1)}
+		s.pendingSyncs.Store(req.InstanceID, waiter)
+
+		_, err := client.SendPeerMessage(ctx, msg)
+		if err != nil {
+			s.pendingSyncs.Delete(req.InstanceID)
+
+			if len(allMessages) > 0 && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				return allMessages, nil
+			}
+			return nil, err
+		}
+
+		// Wait for the phone to respond.
+		var evt *events.HistorySync
+		select {
+		case evt = <-waiter.ch:
+			s.pendingSyncs.Delete(req.InstanceID)
+		case <-time.After(syncTimeout):
+			s.pendingSyncs.Delete(req.InstanceID)
+
+			if len(allMessages) > 0 {
+				return allMessages, nil
+			}
+			return nil, ErrSyncTimeout
+		case <-ctx.Done():
+			s.pendingSyncs.Delete(req.InstanceID)
+			if len(allMessages) > 0 {
+				return allMessages, nil
+			}
+			return nil, ctx.Err()
+		}
+
+		var sinceTS int64
+		if req.Since != nil {
+			sinceTS = req.Since.Unix()
+		}
+
+		var oldestTS int64 = anchorTS
+		oldestID := ""
+		var oldestFromMe *bool
+		pageHasMessages := false
+
+	pageLoop:
+		for _, conv := range evt.Data.GetConversations() {
+			for _, hsm := range conv.GetMessages() {
+				if hsm.Message == nil || hsm.Message.Message == nil {
+					continue
+				}
+
+				ts := hsm.Message.GetMessageTimestamp()
+
+				if sinceTS > 0 && int64(ts) < sinceTS {
+					continue
+				}
+
+				md := s.buildMessageDataFromHistory(hsm.Message, conv.GetName(), conv.GetDisplayName())
+				if md == nil {
+					continue
+				}
+				md.InstanceId = req.InstanceID
+				allMessages = append(allMessages, *md)
+				pageHasMessages = true
+
+				if ts > 0 && uint64(oldestTS) > ts {
+					oldestTS = int64(ts)
+					oldestID = hsm.Message.GetKey().GetID()
+					fromMe := hsm.Message.GetKey().GetFromMe()
+					oldestFromMe = &fromMe
+				}
+
+				if len(allMessages) >= maxSyncMessages {
+					break pageLoop
+				}
+			}
+		}
+
+		// No more messages to fetch, or the per-request message cap was hit.
+		if !pageHasMessages || len(allMessages) >= maxSyncMessages {
+			return allMessages, nil
+		}
+
+		// If no Since filter, return after the first page.
+		if req.Since == nil {
+			return allMessages, nil
+		}
+
+		if oldestTS <= sinceTS {
+			return allMessages, nil
+		}
+
+		// Prepare for next page: anchor becomes the oldest received message,
+		// keeping its ID + fromMe so the phone recognizes the reference point.
+		anchorTS = oldestTS
+		if oldestID != "" {
+			req.ID = oldestID
+			req.FromMe = oldestFromMe
+		}
+	}
+}

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -44,6 +44,8 @@ type Whatsmiau struct {
 	httpClient         *http.Client
 	fileStorage        interfaces.Storage
 	handlerSemaphore   chan struct{}
+	pendingSyncs       *xsync.Map[string, *pendingSyncWaiter]
+	syncLocks          *xsync.Map[string, *sync.Mutex]
 }
 
 var instance *Whatsmiau
@@ -187,6 +189,8 @@ func LoadMiau(ctx context.Context, container *sqlstore.Container) {
 		},
 		fileStorage:      storage,
 		handlerSemaphore: make(chan struct{}, env.Env.HandlerSemaphoreSize),
+		pendingSyncs:     xsync.NewMap[string, *pendingSyncWaiter](),
+		syncLocks:        xsync.NewMap[string, *sync.Mutex](),
 	}
 
 	go instance.startEmitter()

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -390,7 +390,7 @@ func buildProfilePictureResponse(jid *types.JID, url string) dto.FetchProfilePic
 
 // SyncChatMessages godoc
 // @Summary      Sync chat messages on demand
-// @Description  Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.
+// @Description  Requests message history for a chat from the user's primary device (on-demand history sync). The primary device (phone) must have a server-connected WhatsApp session — history is served from its local message store. The `id` anchor is required: history is returned backwards from it, `count` messages per page (default 50). Optionally paginates back to a target date with `since`. A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.
 // @Tags         Chat
 // @Accept       json
 // @Produce      json

--- a/server/controllers/chat.go
+++ b/server/controllers/chat.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/verbeux-ai/whatsmiau/lib/whatsmiau"
 	"github.com/verbeux-ai/whatsmiau/server/dto"
 	"github.com/verbeux-ai/whatsmiau/utils"
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -384,4 +386,80 @@ func buildProfilePictureResponse(jid *types.JID, url string) dto.FetchProfilePic
 		resp.ProfilePictureUrl = &url
 	}
 	return resp
+}
+
+// SyncChatMessages godoc
+// @Summary      Sync chat messages on demand
+// @Description  Requests message history for a chat from the user's primary device (on-demand history sync). The phone must be online. Optionally filters by date (since). History is returned backwards from the anchor (or the most recent messages when no anchor is provided). A single request returns at most 500 messages. Recommended not to be used for bulk history extraction.
+// @Tags         Chat
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        instance  path      string                        true  "Instance ID"
+// @Param        body      body      dto.SyncChatMessagesRequest   true  "Sync parameters"
+// @Success      200       {array}   whatsmiau.WookMessageData     "Messages synced from the chat"
+// @Failure      400       {object}  utils.HTTPErrorResponse
+// @Failure      409       {object}  utils.HTTPErrorResponse
+// @Failure      422       {object}  utils.HTTPErrorResponse
+// @Failure      500       {object}  utils.HTTPErrorResponse
+// @Failure      504       {object}  utils.HTTPErrorResponse
+// @Router       /v1/instance/{instance}/chat/syncMessages [post]
+// @Router       /v1/chat/syncMessages/{instance} [post]
+func (s *Chat) SyncChatMessages(ctx echo.Context) error {
+	var request dto.SyncChatMessagesRequest
+	if err := ctx.Bind(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusUnprocessableEntity, err, "failed to bind request body")
+	}
+
+	if err := validator.New().Struct(&request); err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid request body")
+	}
+
+	chat, err := numberToJid(request.Number)
+	if err != nil {
+		return utils.HTTPFail(ctx, http.StatusBadRequest, err, "invalid number")
+	}
+
+	var since *time.Time
+	if request.Since != "" {
+		parsed, parseErr := parseSyncSince(request.Since)
+		if parseErr != nil {
+			return utils.HTTPFail(ctx, http.StatusBadRequest, parseErr, "invalid since (use YYYY-MM-DD or RFC3339)")
+		}
+		since = &parsed
+	}
+
+	messages, err := s.whatsmiau.SyncChatMessages(ctx.Request().Context(), &whatsmiau.SyncChatMessagesRequest{
+		InstanceID: request.InstanceID,
+		Chat:       *chat,
+		Count:      request.Count,
+		Since:      since,
+		ID:         request.ID,
+		FromMe:     request.FromMe,
+	})
+	if err != nil {
+		zap.L().Error("Whatsmiau.SyncChatMessages failed", zap.Error(err))
+		switch {
+		case errors.Is(err, whatsmiau.ErrSyncTimeout):
+			return utils.HTTPFail(ctx, http.StatusGatewayTimeout, err, "phone did not respond in time")
+		case errors.Is(err, whatsmeow.ErrClientIsNil):
+			return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "instance not found")
+		case strings.Contains(err.Error(), "client not connected"):
+			return utils.HTTPFail(ctx, http.StatusConflict, err, "client not connected")
+		default:
+			return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to sync chat messages")
+		}
+	}
+
+	if messages == nil {
+		messages = []whatsmiau.WookMessageData{}
+	}
+	return ctx.JSON(http.StatusOK, messages)
+}
+
+func parseSyncSince(input string) (time.Time, error) {
+	if t, err := time.Parse("2006-01-02", input); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, input)
 }

--- a/server/dto/chat.go
+++ b/server/dto/chat.go
@@ -86,3 +86,12 @@ type FetchProfilePictureResponse struct {
 	Wuid              string  `json:"wuid"`
 	ProfilePictureUrl *string `json:"profilePictureUrl"`
 }
+
+type SyncChatMessagesRequest struct {
+	InstanceID string `param:"instance" validate:"required" swaggerignore:"true"`
+	Number     string `json:"number" validate:"required"`
+	ID         string `json:"id" validate:"required"`
+	Count      int    `json:"count" validate:"omitempty,min=1,max=100"`
+	Since      string `json:"since,omitempty"`
+	FromMe     *bool  `json:"fromMe,omitempty"`
+}

--- a/server/routes/chat.go
+++ b/server/routes/chat.go
@@ -15,6 +15,7 @@ func Chat(group *echo.Group) {
 	group.POST("/presence", controller.SendChatPresence)
 	group.POST("/read-messages", controller.ReadMessages)
 	group.DELETE("/deleteMessageForEveryone", controller.DeleteMessageForEveryone)
+	group.POST("/syncMessages", controller.SyncChatMessages)
 }
 
 func ChatEVO(group *echo.Group) {
@@ -28,4 +29,5 @@ func ChatEVO(group *echo.Group) {
 	group.POST("/updateMessage/:instance", controller.UpdateMessage)
 	group.POST("/fetchProfilePictureUrl/:instance", controller.FetchProfilePicture)
 	group.DELETE("/deleteMessageForEveryone/:instance", controller.DeleteMessageForEveryone)
+	group.POST("/syncMessages/:instance", controller.SyncChatMessages)
 }

--- a/server/routes/contracts.go
+++ b/server/routes/contracts.go
@@ -35,7 +35,7 @@ func DocumentedV1Operations() []Operation {
 		appendOperation(http.MethodPost, "/v1/message/"+action+"/{instance}")
 	}
 
-	appendOperation(http.MethodPost, "/v1/instance/{instance}/chat/presence", "/v1/instance/{instance}/chat/read-messages", "/v1/chat/markMessageAsRead/{instance}", "/v1/chat/sendPresence/{instance}", "/v1/chat/whatsappNumbers/{instance}", "/v1/chat/updateMessage/{instance}", "/v1/chat/fetchProfilePictureUrl/{instance}")
+	appendOperation(http.MethodPost, "/v1/instance/{instance}/chat/presence", "/v1/instance/{instance}/chat/read-messages", "/v1/instance/{instance}/chat/syncMessages", "/v1/chat/markMessageAsRead/{instance}", "/v1/chat/sendPresence/{instance}", "/v1/chat/whatsappNumbers/{instance}", "/v1/chat/updateMessage/{instance}", "/v1/chat/fetchProfilePictureUrl/{instance}", "/v1/chat/syncMessages/{instance}")
 	appendOperation(http.MethodDelete, "/v1/instance/{instance}/chat/deleteMessageForEveryone", "/v1/chat/deleteMessageForEveryone/{instance}")
 
 	groupActions := []struct {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
Adds `POST /chat/syncMessages/:instance` that requests message history from the user's primary device (on-demand history sync via `HISTORY_SYNC_ON_DEMAND` peer message).
                                                                                                                                                                                                                                    
## Checklist

- [x] Code follows project standards
- [x] Documentation updated (if applicable)
- [x] Tests executed successfully   