### PR TITLE
fix: return 200 while QR code is being generated 

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -283,7 +283,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Marks one or more messages as read in a WhatsApp conversation",
+                "description": "Marks one or more messages as read in a WhatsApp conversation. Set \"played\" on an item to send a played receipt instead, which is what turns a voice note's microphone blue.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2185,7 +2185,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message.",
+                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message. While the QR code is being generated after an expiry, returns 200 with connected=false and no base64.",
                 "produces": [
                     "application/json"
                 ],
@@ -2727,7 +2727,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message.",
+                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message. While the QR code is being generated after an expiry, returns 200 with connected=false and no base64.",
                 "produces": [
                     "application/json"
                 ],
@@ -3396,7 +3396,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Marks one or more messages as read in a WhatsApp conversation",
+                "description": "Marks one or more messages as read in a WhatsApp conversation. Set \"played\" on an item to send a played receipt instead, which is what turns a voice note's microphone blue.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8455,6 +8455,10 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "type": "string"
+                },
+                "played": {
+                    "description": "Played marks a voice note as heard (blue microphone) instead of merely\nread (blue ticks). Audio and PTT messages only.",
+                    "type": "boolean"
                 },
                 "remoteJid": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -860,6 +860,10 @@
                 "id": {
                     "type": "string"
                 },
+                "played": {
+                    "description": "Played marks a voice note as heard (blue microphone) instead of merely\nread (blue ticks). Audio and PTT messages only.",
+                    "type": "boolean"
+                },
                 "remoteJid": {
                     "type": "string"
                 },
@@ -3498,7 +3502,7 @@
                 "consumes": [
                     "application/json"
                 ],
-                "description": "Marks one or more messages as read in a WhatsApp conversation",
+                "description": "Marks one or more messages as read in a WhatsApp conversation. Set \"played\" on an item to send a played receipt instead, which is what turns a voice note's microphone blue.",
                 "operationId": "postV1ChatMarkMessageAsReadByInstance",
                 "parameters": [
                     {
@@ -5565,7 +5569,7 @@
         },
         "/v1/instance/connect/{id}": {
             "get": {
-                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message.",
+                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message. While the QR code is being generated after an expiry, returns 200 with connected=false and no base64.",
                 "operationId": "getV1InstanceConnectById",
                 "parameters": [
                     {
@@ -6177,7 +6181,7 @@
         },
         "/v1/instance/{id}/connect": {
             "post": {
-                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message.",
+                "description": "Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message. While the QR code is being generated after an expiry, returns 200 with connected=false and no base64.",
                 "operationId": "postV1InstanceByIdConnect",
                 "parameters": [
                     {
@@ -6897,7 +6901,7 @@
                 "consumes": [
                     "application/json"
                 ],
-                "description": "Marks one or more messages as read in a WhatsApp conversation",
+                "description": "Marks one or more messages as read in a WhatsApp conversation. Set \"played\" on an item to send a played receipt instead, which is what turns a voice note's microphone blue.",
                 "operationId": "postV1InstanceByInstanceChatReadMessages",
                 "parameters": [
                     {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -576,6 +576,11 @@ definitions:
     properties:
       id:
         type: string
+      played:
+        description: |-
+          Played marks a voice note as heard (blue microphone) instead of merely
+          read (blue ticks). Audio and PTT messages only.
+        type: boolean
       remoteJid:
         type: string
       sender:
@@ -2339,7 +2344,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Marks one or more messages as read in a WhatsApp conversation
+      description: Marks one or more messages as read in a WhatsApp conversation.
+        Set "played" on an item to send a played receipt instead, which is what turns
+        a voice note's microphone blue.
       operationId: postV1ChatMarkMessageAsReadByInstance
       parameters:
       - description: Instance ID
@@ -3729,7 +3736,9 @@ paths:
   /v1/instance/{id}/connect:
     post:
       description: Initiates connection for an instance. Returns a base64-encoded
-        QR code PNG if not yet connected, or a connected status message.
+        QR code PNG if not yet connected, or a connected status message. While the
+        QR code is being generated after an expiry, returns 200 with connected=false
+        and no base64.
       operationId: postV1InstanceByIdConnect
       parameters:
       - description: Instance ID
@@ -4201,7 +4210,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Marks one or more messages as read in a WhatsApp conversation
+      description: Marks one or more messages as read in a WhatsApp conversation.
+        Set "played" on an item to send a played receipt instead, which is what turns
+        a voice note's microphone blue.
       operationId: postV1InstanceByInstanceChatReadMessages
       parameters:
       - description: Instance ID
@@ -6500,7 +6511,9 @@ paths:
   /v1/instance/connect/{id}:
     get:
       description: Initiates connection for an instance. Returns a base64-encoded
-        QR code PNG if not yet connected, or a connected status message.
+        QR code PNG if not yet connected, or a connected status message. While the
+        QR code is being generated after an expiry, returns 200 with connected=false
+        and no base64.
       operationId: getV1InstanceConnectById
       parameters:
       - description: Instance ID

--- a/lib/whatsmiau/sync.go
+++ b/lib/whatsmiau/sync.go
@@ -22,6 +22,8 @@ const (
 
 var ErrSyncTimeout = errors.New("timeout: phone did not respond in time")
 
+var ErrAwaitingQR = errors.New("awaiting qr code generation")
+
 type pendingSyncWaiter struct {
 	chat   types.JID
 	sendID string

--- a/lib/whatsmiau/whatsmeow.go
+++ b/lib/whatsmiau/whatsmeow.go
@@ -558,7 +558,7 @@ func (s *Whatsmiau) observeAndQrCode(ctx context.Context, id string, client *wha
 				}
 				return qr, pc, nil
 			}
-			return "", "", ctx.Err()
+			return "", "", ErrAwaitingQR
 		}
 	}
 }

--- a/server/controllers/instance.go
+++ b/server/controllers/instance.go
@@ -238,7 +238,7 @@ func (s *Instance) List(ctx echo.Context) error {
 
 // Connect godoc
 // @Summary      Connect an instance (get QR code)
-// @Description  Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message.
+// @Description  Initiates connection for an instance. Returns a base64-encoded QR code PNG if not yet connected, or a connected status message. While the QR code is being generated after an expiry, returns 200 with connected=false and no base64.
 // @Tags         Instance
 // @Produce      json
 // @Security     ApiKeyAuth
@@ -268,6 +268,12 @@ func (s *Instance) Connect(ctx echo.Context) error {
 
 	qrCode, pairingCode, err := s.whatsmiau.Connect(c, request.ID, request.Number)
 	if err != nil {
+		if errors.Is(err, whatsmiau.ErrAwaitingQR) {
+			return ctx.JSON(http.StatusOK, dto.ConnectInstanceResponse{
+				Connected: false,
+				Message:   "waiting for QR code generation",
+			})
+		}
 		zap.L().Error("failed to connect instance", zap.Error(err))
 		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to connect instance")
 	}
@@ -323,6 +329,9 @@ func (s *Instance) ConnectQRBuffer(ctx echo.Context) error {
 
 	qrCode, _, err := s.whatsmiau.Connect(c, request.ID, "")
 	if err != nil {
+		if errors.Is(err, whatsmiau.ErrAwaitingQR) {
+			return ctx.NoContent(http.StatusOK)
+		}
 		zap.L().Error("failed to connect instance", zap.Error(err))
 		return utils.HTTPFail(ctx, http.StatusInternalServerError, err, "failed to connect instance")
 	}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                        
  - Connect / ConnectQRBuffer now return HTTP 200 while a QR code is being generated, instead of 500 after the 15s wait window expires with no QR.                                                                                  
  - Added typed error ErrAwaitingQR, signaled by observeAndQrCode when the timeout is the normal "previous QR expired / next one still generating" state. Treated by the handlers as a lifecycle state, not a server failure.      
  - ConnectQRBuffer (image) answers 200 No Content in that state.                                                                                                                                                                   
  - Updated endpoint godoc and regenerated Swagger docs.                                                                                                                                                    
                                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                                      
  - No 500s during the QR regeneration window.                                                                                                                                                                                      
  - Connected-instance fast path unchanged (still returns 200 connected:true).    