### PR TITLE
fix: replace zap.Panic with error return in instance lookup      

### DIFF
--- a/lib/whatsmiau/event_emitter.go
+++ b/lib/whatsmiau/event_emitter.go
@@ -39,7 +39,8 @@ func (s *Whatsmiau) getInstance(id string) *models.Instance {
 
 	res, err := s.repo.List(ctx, id)
 	if err != nil {
-		zap.L().Panic("failed to get instanceCached by instance", zap.Error(err))
+		zap.L().Error("failed to get instanceCached by instance", zap.Error(err))
+		return nil
 	}
 
 	if len(res) == 0 {
@@ -61,7 +62,8 @@ func (s *Whatsmiau) getInstanceCached(id string) *models.Instance {
 
 	res, err := s.repo.List(ctx, id)
 	if err != nil {
-		zap.L().Panic("failed to get instanceCached by instance", zap.Error(err))
+		zap.L().Error("failed to get instanceCached by instance", zap.Error(err))
+		return nil
 	}
 
 	if len(res) == 0 {


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                       
Replace `zap.L().Panic` with `zap.Error` + `return nil` in `getInstance`/`getInstanceCached` (event_emitter.go).                                                                                                                  
                                                                                                                                                                                                                                    
**_Before:_** Redis outage during connect → panic in bare goroutine (observeConnection) → whole process crash, all instances down.                                                                                                      
**_After:_** Redis outage → error logged, nil returned (all 6 call sites already handle nil) → connect proceeds, events resume when Redis returns.

## Checklist

- [x] Code follows project standards
- [ ] Documentation updated (if applicable)
- [x] Tests executed successfully   